### PR TITLE
Win compile support

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -36,11 +36,7 @@ jobs:
 
   compile-examples:
     needs: set-ci-matrix
-    runs-on:
-      - ubuntu-latest
-      # TODO: We will later add support for other platforms
-      # - windows-latest
-      # - macos-latest 
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix: ${{fromJson(needs.set-ci-matrix.outputs.matrix)}}
@@ -59,14 +55,21 @@ jobs:
           repository: Infineon/arduino-devops
           ref: latest
           path: arduino-devops
-        
-      - name: Install arduino-cli
-        # TODO: We need to find a way to install the arduino-cli for multiple OS
-        # without the need of containers
+
+      - name: Install Python dependencies
         run: |
-          curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh -s 1.1.0
-          sudo mv bin/arduino-cli /usr/local/bin/arduino-cli
-          arduino-cli version
+            python -m pip install --upgrade pip
+            pip install -r arduino-devops/requirements.txt
+        
+      - name: Install arduino-cli Linux
+        if: runner.os == 'Linux'
+        run: |
+          ./arduino-devops/arduino-cli-install.sh 1.1.0
+
+      - name: Install arduino-cli Windows
+        if: runner.os == 'Windows'
+        run: |
+          .\arduino-devops\arduino-cli-install.ps1 1.1.0 
 
       - name: Core setup
         if : ${{ inputs.setup-script }} != null

--- a/arduino-cli-install.ps1
+++ b/arduino-cli-install.ps1
@@ -1,0 +1,16 @@
+# The installation version is passed as argument
+$arduino_cli_version = $args[0]
+
+# Retrieve the arduino cli installation bash script
+Invoke-WebRequest -Uri https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh -OutFile cli-install.sh
+
+# Run the bash script to install the arduino cli
+& bash.exe -c "sh cli-install.sh $arduino_cli_version"
+
+# The arduino-cli installation path should be added to the system path.
+# But these commands are not working within the GitHub Action workflow:
+# >  Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" -Name "Path" -Value ("$(pwd)/bin;" + $env:Path) -Type String
+# >  [Environment]::SetEnvironmentVariable("Path", "$(pwd)/bin;" + $env:Path, "Machine")
+# So we will copy the arduino-cli.exe to the first path in the system path.
+$path_in_sys_path = $env:PATH.Split(";")[0]
+Copy-Item -Path "$(pwd)\bin\arduino-cli.exe" -Destination "$path_in_sys_path"

--- a/arduino-cli-install.sh
+++ b/arduino-cli-install.sh
@@ -1,0 +1,5 @@
+# Get the version from the command line arguments
+ard_cli_version= $1
+curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh -s $ard_cli_version
+sudo mv bin/arduino-cli /usr/local/bin/arduino-cli
+arduino-cli version

--- a/pckg-install-local.py
+++ b/pckg-install-local.py
@@ -342,7 +342,7 @@ class PckgLocalInstaller:
         pckgr_core_name = self.__get_core_packager_name()
 
         try:
-            local_pckg_index_url = os.path.join(
+            local_pckg_index_url = "{}/{}".format(
                 self.server_url, self.local_pckg_index_name
             )
             logging.info(f'Installing core package from url "{local_pckg_index_url}"')
@@ -408,7 +408,7 @@ class PckgLocalInstallParser:
         """
         # Get the script name without .py extension
         self.installer_tool_name = os.path.splitext(os.path.basename(__file__))[0]
-        self.installer_tool_version = "0.1.0"
+        self.installer_tool_version = "0.1.1"
         self.__create_parser()
 
         args = self.parser.parse_args(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML
+requests


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Added support for compile-example in Windows OS.
* Added scripts to install arduino-cli and add it to the system path in both Linux and Windows.
* Added requirements.txt with libraries (which were not available in Windows).
* Fixed temporary server url path creation (using forward slashes independently of the OS).