### PR TITLE
Add workflow for Arduino library build check.

### DIFF
--- a/.github/workflows/lib-compile-examples.yml
+++ b/.github/workflows/lib-compile-examples.yml
@@ -1,0 +1,54 @@
+name: Build examples
+
+on:
+  workflow_call:
+
+jobs:
+  build-examples:
+    name: ${{ matrix.board.fqbn }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        board:
+          - fqbn: arduino:avr:uno
+          - fqbn: arduino:avr:nano
+          - fqbn: arduino:avr:mega
+          - fqbn: arduino:renesas_uno:minima
+          - fqbn: arduino:renesas_uno:unor4wifi
+          - fqbn: arduino:samd:mkrzero
+          - fqbn: "Infineon:xmc:XMC1100_XMC2GO"
+          - fqbn: "Infineon:xmc:XMC1300_Boot_Kit"
+          - fqbn: "Infineon:xmc:XMC1400_XMC2GO"
+          - fqbn: "Infineon:xmc:XMC1400_Arduino_Kit"
+          - fqbn: "Infineon:xmc:XMC4700_Relax_Kit"
+          - fqbn: "Infineon:xmc:XMC1100_Boot_Kit"
+          - fqbn: "infineon:psoc6:cy8ckit_062s2_ai"
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+    
+      - name: Compile Arduino examples
+        if: contains(matrix.board.fqbn, 'arduino:')
+        uses: arduino/compile-sketches@v1
+        with:
+          fqbn: ${{ matrix.board.fqbn }}
+      
+      - name: Compile Infineon XMC examples
+        if: contains(matrix.board.fqbn, 'Infineon:xmc')
+        uses: arduino/compile-sketches@v1
+        with:
+          fqbn: ${{ matrix.board.fqbn }}
+          platforms: |
+              - name: Infineon:xmc
+                source-url: https://github.com/Infineon/XMC-for-Arduino/releases/latest/download/package_infineon_index.json
+      
+      - name: Compile Infineon PSOC6 examples
+        if: contains(matrix.board.fqbn, 'infineon:psoc6')
+        uses: arduino/compile-sketches@v1
+        with:
+          fqbn: ${{ matrix.board.fqbn }}
+          platforms: |
+              - name: infineon:psoc6
+                source-url: https://github.com/Infineon/arduino-core-psoc6/releases/latest/download/package_psoc6_index.json

--- a/.github/workflows/lib-compile-examples.yml
+++ b/.github/workflows/lib-compile-examples.yml
@@ -4,14 +4,26 @@ on:
   workflow_call:
 
 jobs:
-  build-examples:
+  build-arduino-uno:
+    name: Arduino Uno (Prerequisite for build-matrix)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+    
+      - name: Compile examples
+        uses: arduino/compile-sketches@v1
+        with:
+          fqbn: arduino:avr:uno
+          
+  build-matrix:
+    needs: build-arduino-uno
     name: ${{ matrix.board.fqbn }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         board:
-          - fqbn: arduino:avr:uno
           - fqbn: arduino:avr:nano
           - fqbn: arduino:avr:mega
           - fqbn: arduino:renesas_uno:minima

--- a/.github/workflows/lib-compile-examples.yml
+++ b/.github/workflows/lib-compile-examples.yml
@@ -1,5 +1,18 @@
 name: Build examples
 
+### QUICK REFERENCE ###
+
+# Requires Arduino library structure in the calling repository.
+# See: https://docs.arduino.cc/arduino-cli/library-specification/
+
+# How to call this workflow from another workflow:
+# name: Build examples
+# on:
+#  ...
+# jobs:
+#   build-examples:
+#     uses: Infineon/arduino-devops/.github/workflows/lib-compile-examples.yml@main
+
 on:
   workflow_call:
 
@@ -15,7 +28,7 @@ jobs:
         uses: arduino/compile-sketches@v1
         with:
           fqbn: arduino:avr:uno
-          
+
   build-matrix:
     needs: build-arduino-uno
     name: ${{ matrix.board.fqbn }}


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

## Description
This PR adds a reusable build check workflow for Arduino **libraries**.

### Coverage:
Using this workflow, the following boards are checked by default:
```
- fqbn: arduino:avr:uno
- fqbn: arduino:avr:nano
- fqbn: arduino:avr:mega
- fqbn: arduino:renesas_uno:minima
- fqbn: arduino:renesas_uno:unor4wifi
- fqbn: arduino:samd:mkrzero
- fqbn: "Infineon:xmc:XMC1100_XMC2GO"
- fqbn: "Infineon:xmc:XMC1300_Boot_Kit"
- fqbn: "Infineon:xmc:XMC1400_XMC2GO"
- fqbn: "Infineon:xmc:XMC1400_Arduino_Kit"
- fqbn: "Infineon:xmc:XMC4700_Relax_Kit"
- fqbn: "Infineon:xmc:XMC1100_Boot_Kit"
- fqbn: "infineon:psoc6:cy8ckit_062s2_ai"
```

### Efficiency Considerations
To save build time and Action minutes this workflow is separated into two jobs:
- Build Arduino Uno
- Run full build matrix

If build for Arduino Uno fails, the matrix is **not** executed.

### Example
To see the workflow in action have a look here: https://github.com/Infineon/arduino-xensiv-angle-sensor-tlx5012/actions/runs/14082413347