### PR TITLE
Compile examples workflows split in OS and per fqbn jobs

### DIFF
--- a/.github/workflows/compile-examples-os.yml
+++ b/.github/workflows/compile-examples-os.yml
@@ -1,0 +1,66 @@
+name: Compile examples for OS
+
+on:
+  push:
+  pull_request:
+  workflow_call:
+    inputs:
+      ci-matrix-json:
+        required: true
+        type: string
+        description: 'The ci compile matrix in JSON format'
+      setup-script:
+        required: false
+        type: string
+        default: null
+        description: 'Any setup script to run before compiling the examples'
+      os:
+        required: true
+        type: string
+        description: 'The operating system to run the job on'
+
+jobs:  
+  compile-examples:
+    name: ${{ inputs.os }} - ${{ matrix.fqbn }}
+    runs-on: ${{ inputs.os }}
+
+    strategy:
+      matrix: ${{fromJson(inputs.ci-matrix-json)}}
+
+    steps:
+      - name: Checkout repository 
+        uses: actions/checkout@v4
+
+      - name: Checkout arduino-devops
+        uses: actions/checkout@v4
+        with:
+          repository: Infineon/arduino-devops
+          ref: latest
+          path: arduino-devops
+          
+      - name: Install python dependencies
+        if: contains(inputs.os, 'windows') || contains(inputs.os, 'macos')
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r arduino-devops/requirements.txt
+
+      - name: Compile setup
+        if : ${{ inputs.setup-script }} != null
+        run: |
+          ${{ inputs.setup-script }}
+
+      - name: Install arduino-cli
+        run: |
+          python ./arduino-devops/arduino-cli-install.py 1.2.0
+
+      - name: Retrieve core package
+        uses: actions/download-artifact@v4
+  
+      - name: Install arduino core
+        run: |
+          # The package is downloaded in the directory arduino-core-package
+          python ./arduino-devops/pckg-install-local.py --pckg-dir arduino-core-package
+
+      - name: Compile sketches
+        run: |
+          python ./arduino-devops/arduino-ci.py compile --fqbn ${{ matrix.fqbn }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -5,19 +5,30 @@ on:
   pull_request:
   workflow_call:
     inputs:
-      setup-script:
+      core-setup-script:
         required: false
         type: string
         default: null
-        description: 'Any setup script to run before building the Arduino package and compiling the examples'
-      ci-matrix-file-json:
-        required: true
+        description: 'Any setup script to run before building the Arduino package'
+      ci-setup-script:
+        required: false
         type: string
-        description: 'The file containing the build matrix in JSON format'
+        default: null
+        description: 'Any setup script to run before compiling the examples'
+      os-list:
+        required: false
+        type: string
+        default: 'ubuntu-latest, windows-latest, macos-latest'
+        description: 'The list of operating systems to run the job on. The list should be a comma-separated string, e.g. "ubuntu-latest,windows-latest,macos-latest"'
 
 jobs:
+  package-core: 
+    uses: Infineon/arduino-devops/.github/workflows/package-core.yml@latest
+    with:
+      setup-script: ${{ inputs.core-setup-script }}
+      release: false
 
-  set-ci-matrix:
+  ci-setup:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -26,62 +37,52 @@ jobs:
       - name: Checkout repository 
         uses: actions/checkout@v4
 
-      - name: Set build matrix
-        id: set-matrix
-        run: |
-          matrix_ci=$(cat ${{ inputs.ci-matrix-file-json }})
-          echo $matrix_ci
-          echo "matrix="$matrix_ci"" >> $GITHUB_OUTPUT
-
-  package-core:
-    uses: Infineon/arduino-devops/.github/workflows/package-core.yml@latest
-    with:
-      setup-script: bash ./tools/dev-setup.sh
-      release: false
-
-  compile-examples:
-    needs: 
-      - set-ci-matrix
-      - package-core 
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix: ${{fromJson(needs.set-ci-matrix.outputs.matrix)}}
-
-    steps:
-      - name: Checkout repository 
-        uses: actions/checkout@v4
-
-      - name: Checkout arduino-devops
+      - name: Checkout arduino-devops 
         uses: actions/checkout@v4
         with:
           repository: Infineon/arduino-devops
           ref: latest
           path: arduino-devops
 
-      - name: Check if arduino-examples exists as a submodule
-        id: check_submodule
+      - name: Set build matrix
+        id: set-matrix
         run: |
-          SUBMODULE_PATH=$(git config --file=.gitmodules --get-regexp 'submodule\..*\.url' | grep "arduino/arduino-examples" | sed -E 's/submodule\.(.*)\.url.*/\1/')
-          if [ -n "$SUBMODULE_PATH" ]; then
-              SUBMODULE_DIRECTORY=$(git config --file=.gitmodules --get "submodule.${SUBMODULE_PATH}.path")
-              git submodule update --init -- "$SUBMODULE_DIRECTORY"
-              echo "Submodule ${SUBMODULE_PATH} initialized and updated."
-          fi
-        shell: bash
+          matrix_ci=$(python ./arduino-devops/arduino-ci.py config --list fqbn)
+          echo $matrix_ci
+          echo "matrix="$matrix_ci"" >> $GITHUB_OUTPUT
 
-      - name: Install arduino-cli
-        run: |
-          python ./arduino-devops/arduino-cli-install.py 1.2.0
+  compile-examples-ubuntu:
+    name: ubuntu
+    if: contains(inputs.os-list, 'ubuntu')
+    needs: 
+      - ci-setup
+      - package-core
+    uses : Infineon/arduino-devops/.github/workflows/compile-examples-os.yml@latest
+    with:
+      ci-matrix-json: ${{ needs.ci-setup.outputs.matrix }}
+      setup-script: ${{ inputs.ci-setup-script }}
+      os: ubuntu-latest
 
-      - name: Retrieve core package
-        uses: actions/download-artifact@v4
-  
-      - name: Install arduino core
-        run: |
-          # The package is donwloaded in the directory arduino-core-package
-          python ./arduino-devops/pckg-install-local.py --pckg-dir arduino-core-package
+  compile-examples-windows:
+    name: windows
+    if: contains(inputs.os-list, 'windows')
+    needs: 
+      - ci-setup
+      - package-core
+    uses : Infineon/arduino-devops/.github/workflows/compile-examples-os.yml@latest
+    with:
+      ci-matrix-json: ${{ needs.ci-setup.outputs.matrix }}
+      setup-script: ${{ inputs.ci-setup-script }}
+      os: windows-latest
 
-      - name: Compile sketch
-        run: |
-          arduino-cli compile --clean --verbose --fqbn ${{ matrix.fqbn }} ${{ matrix.example }}
+  compile-examples-macos:
+    name: macos
+    if: contains(inputs.os-list, 'macos')
+    needs: 
+      - ci-setup
+      - package-core
+    uses : Infineon/arduino-devops/.github/workflows/compile-examples-os.yml@latest
+    with:
+      ci-matrix-json: ${{ needs.ci-setup.outputs.matrix }}
+      setup-script: ${{ inputs.ci-setup-script }}
+      os: macos-latest

--- a/.github/workflows/package-core.yml
+++ b/.github/workflows/package-core.yml
@@ -9,7 +9,7 @@ on:
         required: false
         type: string
         default: null
-        description: 'Any setup script to run before building the Arduino package and compiling the examples'
+        description: 'Any setup script to run before building the Arduino package'
       release:
         required: false
         type: boolean

--- a/arduino-ci.py
+++ b/arduino-ci.py
@@ -1,0 +1,744 @@
+import argparse
+import json
+import logging
+import os
+import sys
+import subprocess
+import yaml
+""" File that needs to be parsed """
+
+# Create logging
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+
+class CiMatrixConfig:
+    """
+    Class to parse the release configuration file
+
+    The yaml file needs the following keys:
+    """
+    def __init__(self, ci_matrix_yml, asset_root_path):
+        self.ci_matrix_file = ci_matrix_yml
+        self.config = {}
+        self.asset_root_path = asset_root_path
+        self.extra_sketch_paths = []
+        self.sketch_core_default_path = ["libraries"]
+        self.sketch_library_default_path = ["examples"]
+        self.asset_type = None
+
+        if ci_matrix_yml is not None:
+            self.config = self.__parse_config()
+
+        if "asset_type" in self.config:
+            self.asset_type = self.config["asset_type"]
+        else:
+            self.__asset_type_discover()
+
+        if "fqbn" not in self.config:
+            self.config["fqbn"] = self.__fqbn_list_default()
+        
+        if "sketch" not in self.config:
+            self.config["sketch"] = self.__sketch_list_default()
+
+    def __str__(self):
+        """Returns json not formatted"""
+        return str(self.config)
+
+    def __str__as_yml(self):
+        """Uses yaml dump to generate a string"""
+        return yaml.dump(self.config, indent=4, default_flow_style=False)
+        return str(self.config)
+    
+    def __str__as_json_pretty(self):
+        """Uses json dump to generate a pretty string"""
+        return json.dumps(self.config, indent=4)
+
+    def get_list(self, query_key, filter=None):
+        """
+        List all the elements of a given key ("fqbn" or "sketch") in the configuration matrix.
+        If filter is provided, it will filter the list based on the value of another key.
+        """
+
+        logging.info(f"Querying the configuration matrix for key \"{query_key}\" and filter \"{filter}\"")
+
+        queried_list = { query_key: [] }
+
+        if self.__is_key_valid(query_key):
+            
+            if filter is None:
+                queried_list = self.__query(query_key)
+            else:
+                queried_list = self.__filtered_query(query_key, filter)
+
+        
+        queried_list[query_key] = sorted(queried_list[query_key], key=str.lower)
+        
+        return queried_list
+        
+    """ Private methods """
+
+    def __parse_config(self):
+        """Parses the matrix ci yml file"""
+        config = {}
+        try:
+            with open(self.ci_matrix_file, "r") as f:
+                config = yaml.safe_load(f)
+                if config is None:
+                    config = {}
+        except FileNotFoundError:
+            logging.warning("The ci matrix config file was not found. Default or discovered \"sketches\" and/or \"fqbn\" will be used.")
+
+        return config
+
+    def __fqbn_list_default(self):
+
+        def library_fqbn_list_default():
+            return [] # This will be the default values chosen by Julian. If not added by the library, the arduino-devops can provide one.
+        
+        def core_fqbn_list_auto_discovery():
+
+            fqbn_list = []
+                    
+            boards_txt = os.path.exists(os.path.join(self.asset_root_path, "boards.txt"))
+            if not boards_txt:
+                logging.error(f"\"boards.txt\" file not found in the asset root path \"{self.asset_root_path}\"")
+                sys.exit(1)
+            
+            # Load content of boards.txt file
+            with open(os.path.join(self.asset_root_path, "boards.txt"), "r") as f:
+                boards_txt_content = f.read()
+
+            # look for the lines with pattern <prefix>.name=<board_name> and
+            # extract the prefix in board_txt_content
+            # The prefix is the fqbn
+   
+            board_name_list = []
+            for line in boards_txt_content.splitlines():
+                if line.startswith("#") or line.strip() == "":
+                    continue
+                if ".name=" in line:
+                    prefix = line.split(".name=")[0].strip()
+                    if prefix not in board_name_list:
+                        board_name_list.append(prefix)
+                        logging.info(f"Found fqbn: \"{prefix}\"")
+
+            # remove duplicates
+            board_name_list = list(set(board_name_list))
+
+            # Find vendor and core name
+            package_index_template_dir = os.path.join(self.asset_root_path, "package")
+            if not os.path.exists(package_index_template_dir):
+                logging.error(f"\"package\" dir not found in the asset root path \"{self.asset_root_path}\"")
+                sys.exit(1)
+
+            # Find in the dir a .json file
+            for root, dirs, files in os.walk(package_index_template_dir):
+                for file in files:
+                    if file.endswith(".json") and "package" in file and "index" in file:
+                        package_index_template_file = os.path.join(root, file)
+                        break
+
+            # Load content of package_index_template_file   
+            with open(package_index_template_file, "r") as f:
+                package_index_template_content = json.load(f)
+
+            try:
+                vendor_name = package_index_template_content["packages"][0]["name"]
+                arch_name = package_index_template_content["packages"][0]["platforms"][0]["architecture"]
+            except KeyError:
+                logging.error(f"Key not found in the package index template file \"{package_index_template_file}\"")
+                sys.exit(1)
+
+            for board in board_name_list:
+                fqbn = f"{vendor_name}:{arch_name}:{board}"
+                fqbn_list.append(fqbn)
+                logging.info(f"Found fqbn: \"{fqbn}\"")
+
+            return fqbn_list
+
+        fqbn_list = []
+        if self.asset_type == "library":
+           fqbn_list =  library_fqbn_list_default()
+        elif self.asset_type == "core":
+           fqbn_list = core_fqbn_list_auto_discovery()
+        else:
+            logging.error(f"Asset type \"{self.asset_type}\" not supported. Supported types are: \"library\" and \"core\"")
+            sys.exit(1)
+        
+        return fqbn_list
+
+    def __sketch_list_default(self):
+
+        def sketch_list_auto_discovery(sketch_path_list):
+            sketch_list = []
+
+            for sketch_path in sketch_path_list:
+                # The default search path is the "sketch" folder
+                sketch_path_abs = os.path.join(self.asset_root_path, sketch_path)
+                if not os.path.exists(sketch_path_abs):
+                    logging.warning(f"\"{sketch_path}\" dir not found in the asset root path \"{self.asset_root_path}\"")
+            
+                # Walk through all the directories in the library path
+                # and list all the files with the .ino extension
+                for root, dirs, files in os.walk(sketch_path_abs):
+                    for file in files:
+                        if file.endswith(".ino"):
+                            # Append only relative path to the asset root path
+                            # to avoid absolute path in the sketch list
+                            sketch_with_full_path = os.path.join(root, file)
+                            sketch_with_relative_path = os.path.relpath(sketch_with_full_path, self.asset_root_path)
+                            sketch_list.append(sketch_with_relative_path)
+                            logging.info(f"Found sketch: \"{sketch_with_relative_path}\"")
+
+        
+            return sketch_list
+
+        sketch_list = []
+        if self.asset_type == "library":
+           sketch_list = sketch_list_auto_discovery(self.sketch_library_default_path)
+        elif self.asset_type == "core":
+           sketch_list = sketch_list_auto_discovery(self.sketch_core_default_path)
+        else:
+            logging.error(f"Asset type \"{self.asset_type}\" not supported. Supported types are: \"library\" and \"core\"")
+            sys.exit(1)
+        
+        return sketch_list
+
+
+    def __asset_type_discover(self):
+        """
+        Discover the asset type based on the root path.
+        The asset type can be either a library or a core.
+        """
+        if os.path.exists(os.path.join(self.asset_root_path, "library.json")):
+            self.asset_type = "library"
+        elif os.path.exists(os.path.join(self.asset_root_path, "platform.txt")) and \
+             os.path.exists(os.path.join(self.asset_root_path, "boards.txt")) and \
+             os.path.exists(os.path.join(self.asset_root_path, "variants")) and \
+             os.path.exists(os.path.join(self.asset_root_path, "cores")):
+            self.asset_type = "core"
+        else:
+            logging.error(f"Asset type not found. The asset root path \"{self.asset_root_path}\" does not contain a valid library or core.")
+            sys.exit(1) 
+
+    def __is_key_valid(self, key):
+        """
+        Validate the key. 
+        - The queryable keys are "fqbn" and "sketch".
+        The rest are not added, as they are modifier for the of the default 
+        matrix or other config parameters.
+        - The key needs to also present at least in the "include" key.
+
+        Args:
+            key (str): The key to be validated.
+        """
+        
+        logging.info(f"Validating key: \"{key}\"")
+        
+        allowed_list_keys = ["fqbn", "sketch"]
+
+        if key not in allowed_list_keys:
+            logging.error(f"Key \"{key}\" is not allowed. Allowed keys are: \"{allowed_list_keys}\"")
+            return False
+
+        key_in_config = False
+        if key in self.config:
+            logging.info(f"Key \"{key}\" found in the configuration matrix")
+            key_in_config = True
+        else:
+            if "include" in self.config:
+                for entry in self.config["include"]:
+                    if key in entry:
+                        logging.info(f"Key \"{key}\" found in \"include\" list")
+                        key_in_config = True
+                        break
+        
+        if not key_in_config:
+            logging.error(f"Key \"{key}\" not found in the configuration matrix")
+            return False
+
+        return True
+
+    def __get_values_from_root_node_key(self, key):
+        values = []
+
+        if key in self.config:
+            # This should be always a list # TODO: Add validation in separate method.
+            values = self.config[key]
+
+        return values
+
+    def __get_values_from_modifier_node_key(self, node, key, single_key_check=False):
+        
+        def single_pair_key_check(node, single_key_check):
+            if single_key_check:
+                if len(node) != 1:
+                    return False
+
+            return True
+
+        values = []
+
+        if node in self.config:
+            # This should always be a list of dictionaries
+            for item in self.config[node]:
+                if key in item and single_pair_key_check(item, single_key_check):
+                    # This can be an str scalar or a list
+                    if isinstance(item[key], list):
+                        values.extend(item[key])
+                    else:
+                        values.append(item[key])
+        return values
+
+    def __get_filtered_values_from_modifier_node_key(self, node, query_key, filter_key, filter_value):
+        
+        values = []
+
+        if node in self.config:
+            # This should always be a list of dictionaries
+            # For filtered values the node should have a pair 
+            # of key-value pairs
+            # The child node should have a query_key dictionary (but still is checked)
+            for child_node in self.config[node]:
+                if filter_key in child_node and \
+                   filter_value in child_node[filter_key] and \
+                   query_key in child_node:
+                        # This can be an str scalar or a list
+                        if isinstance(child_node[query_key], list):
+                            values.extend(child_node[query_key])
+                        else:
+                            values.append(child_node[query_key])
+        
+        return values
+
+    def __query(self, query_key):
+        """
+        It will return the list of values for the queried key.
+        The key is present at least in:
+            - As main node key of the default configuration matrix
+            - As part of the "include" key
+        """
+        queried_list = { query_key: [] }
+
+        # Values from key in root node 
+        root_node_key_values = self.__get_values_from_root_node_key(query_key)
+        queried_list[query_key].extend(root_node_key_values)
+
+        # Values from key in include node
+        include_values = self.__get_values_from_modifier_node_key("include", query_key)
+        queried_list[query_key].extend(include_values)
+        # Remove duplicates
+        queried_list[query_key] = list(set(queried_list[query_key]))
+
+        # Values to exclude if present in the exclude node as single key
+        exclude_values = self.__get_values_from_modifier_node_key("exclude", query_key, single_key_check=True)
+        # Remove the values if they are in the queried_list
+        queried_list[query_key] = [ item for item in queried_list[query_key] if item not in exclude_values ]
+
+        return queried_list
+
+    def __query_same_list_and_filter_key(self, query_filter_key, filter_value):
+        """
+        If the filter key is the same as the list, the user is
+        querying if the value is present in the configuration in 
+        the main matrix or in the include/exclude.
+        """
+        queried_list = { query_filter_key: [] }
+
+        queried_key_values = self.__query(query_filter_key)
+        if filter_value in queried_key_values[query_filter_key]:
+            queried_list[query_filter_key] = [ filter_value ]
+
+        return queried_list
+            
+    def __query_diff_list_and_filter_key(self, query_key, filter_key, filter_value):
+
+        queried_list = { query_key: [] }
+
+        root_node_key_values = self.__get_values_from_root_node_key(filter_key)
+        if filter_value in root_node_key_values:   
+            # If the filter_key is present, the query_key will should be
+            # and its value is a list
+            queried_list[query_key].extend(self.config[query_key])
+
+        # If there is already a base list, add any additional value which applies to the whole matrix
+        if queried_list[query_key] != []:
+            include_values = self.__get_values_from_modifier_node_key("include", query_key, single_key_check=True)
+            queried_list[query_key].extend(include_values)
+            # Remove duplicates
+            queried_list[query_key] = list(set(queried_list[query_key]))
+            
+        # Add include values matching the filtered key from the include node
+        include_values = self.__get_filtered_values_from_modifier_node_key("include", query_key, filter_key, filter_value)
+        queried_list[query_key].extend(include_values)
+        # Remove duplicates
+        queried_list[query_key] = list(set(queried_list[query_key]))
+
+        # Remove exclude values matching the filtered key from the exclude node
+        exclude_values = self.__get_filtered_values_from_modifier_node_key("exclude", query_key, filter_key, filter_value)
+        # Remove any query value that applies to the whole matrix
+        exclude_values.extend(self.__get_values_from_modifier_node_key("exclude", query_key, single_key_check=True))
+        exclude_values = list(set(exclude_values))
+        queried_list[query_key] = [ item for item in queried_list[query_key] if item not in exclude_values ]
+
+        return queried_list
+
+
+    def __filtered_query(self, query_key, filter):
+        """
+        It will return the list of values for the queried key and a filter.
+        """
+        def __validate_filter(filter): 
+            # The filter format should be "key=value"
+            # Validate the filter format
+            if "=" not in filter:
+                logging.error(f"Filter \"{filter}\" is not in the format key=value")
+                return False
+            
+            return True
+            
+        queried_list = { query_key: [] }
+
+        if not __validate_filter(filter):
+            return queried_list
+            
+        filter_key, filter_value = filter.split("=")
+        logging.info(f"Filtering for key \"{filter_key}\" with value \"{filter_value}\"")
+
+        if self.__is_key_valid(filter_key):
+
+            if filter_key == query_key:
+                queried_list = self.__query_same_list_and_filter_key(filter_key, filter_value)
+            else:
+                queried_list = self.__query_diff_list_and_filter_key(query_key, filter_key, filter_value)
+
+        return queried_list
+
+class CiCompileReport:
+    def __init__(self):
+        self.pass_list = []
+        self.fail_list = []
+
+    def add_pass(self, sketch):
+        self.pass_list.append(sketch)
+
+    def get_pass_len(self):
+        return len(self.pass_list)
+    
+    def add_fail(self, sketch):
+        self.fail_list.append(sketch)
+    
+    def get_fail_len(self):
+        return len(self.fail_list)
+
+    def get_total_len(self):
+        return len(self.pass_list) + len(self.fail_list)
+
+    def summary(self):
+        print("\033[94m--------------------------------------------------------")
+        print("----------- Compile sketches report summary ------------")
+        print("--------------------------------------------------------\033[0m")
+
+        if self.get_total_len() == self.get_pass_len():
+            print(f"All \033[92m{self.get_total_len()}\033[0m sketches \033[92mPASSED\033[0m !! :) ")
+        else:
+            if self.get_pass_len() > 0:
+                print(f"Only \033[92m{self.get_pass_len()}\033[0m out of \033[94m{self.get_total_len()}\033[0m sketches PASSED")
+
+            if self.get_fail_len() > 0:
+                if self.get_pass_len() == 0:
+                    print(f"All {self.get_total_len()} sketches \033[91mFAILED\033[0m")
+                else:
+                    print(f"The following sketches have \033[91mFAILED\033[0m")
+                for sketch in self.fail_list:
+                    print(f"   - {sketch}")
+
+        print("\033[94m--------------------------------------------------------\033[0m")
+
+class CiParser:
+    """
+    Class that parses the ci tool arguments
+    """
+
+    def __init__(self):
+        """
+        The constructor creates the argument parser and parses the arguments.
+        """
+        # Get the script name without .py extension
+        self.ci_tool_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.ci_tool_version = "0.1.0"
+        self.__create_parser()
+
+        args = self.parser.parse_args(namespace=argparse.Namespace(ci_parser=self))
+        args.func(args)
+
+        """ Private class methods """
+
+    class __ver_action(argparse.Action):
+        def __init__(self, option_strings, dest, **kwargs):
+            super().__init__(
+                option_strings, dest, nargs=0, default=argparse.SUPPRESS, **kwargs
+            )
+
+        def __call__(self, parser, namespace, values, option_string=None):
+            # Retrieve the package_parser object from the namespace
+            ci_parser = getattr(namespace, "ci_parser", None)
+            print(
+                ci_parser.ci_tool_name
+                + " version: "
+                + ci_parser.ci_tool_version
+            )
+            parser.exit()
+    
+    def __main_parser_func(self, args):
+        """
+        Main parser function of arduino CI cli tool
+        """
+        if args.ci_matrix_yml is None:
+            args.ci_matrix_yml = os.path.join(args.root_path, "ci-matrix-config.yml")
+
+        if args.verbose:
+            # Enable logging info
+            logging.getLogger().setLevel(logging.INFO)
+
+            print(f"Arduino asset root path:      {args.root_path}")
+            print(f"CI matrix configuration file: {args.ci_matrix_yml}")
+
+        ci_config = CiMatrixConfig(args.ci_matrix_yml, args.root_path)
+
+        return ci_config
+    
+    def __config_parser_func(self, args):
+
+        ci_config = self.__main_parser_func(args)
+
+        if args.list is not None:
+            queried_config = ci_config.get_list(args.list, args.filter)
+        else:
+            if args.filter is not None:
+                logging.error(f"The filter option is only available for the list command.")
+                sys.exit(1)
+            
+            queried_config = ci_config.config
+
+        # Print with desired format
+        if args.json_pretty:
+            print(json.dumps(queried_config, indent=4))  
+        elif args.yaml:
+            print(yaml.dump(queried_config, indent=4, default_flow_style=False))
+        else:
+            print(queried_config)
+
+    def __compile_parser_func(self, args):
+
+        def get_sketch_list(self, args, fqbn):
+            """
+            Get the list of sketches for a given fqbn.
+            If a sketch is not provided, then it will get the list
+            from the configuration matrix file.
+            """
+            if args.sketch is None:
+                ci_config = self.__main_parser_func(args)
+                sketch_list = ci_config.get_list("sketch","fqbn=" + fqbn)
+                sketch_list = sketch_list["sketch"]
+            else:
+                sketch_list = [args.sketch]
+        
+            # Iterate over the sketch list. If the 
+            # the sketch is not a .ino file, then it is a directory containing
+            # .ino files. Discover all the .ino files in the directory and 
+            # add them to the sketch list, and remove the directory from the list.
+            remove_dirs = []
+            for sketch in sketch_list:
+                if os.path.isdir(sketch):
+                    # Get all the .ino files in the directory
+                    sketch_dir = os.path.join(args.root_path, sketch)
+                    if not os.path.exists(sketch_dir):
+                        logging.error(f"Sketch directory \"{sketch_dir}\" not found")
+                        sys.exit(1)
+                    for root, dirs, files in os.walk(sketch_dir):
+                        for file in files:
+                            if file.endswith(".ino"):
+                                sketch_with_full_path = os.path.join(root, file)
+                                sketch_with_relative_path = os.path.relpath(sketch_with_full_path, args.root_path)
+                                sketch_list.append(sketch_with_relative_path)
+                    # Remove the directory from the list
+                    remove_dirs.append(sketch)
+
+            # Remove the directories from the list
+            for sketch in remove_dirs:
+                sketch_list.remove(sketch)
+
+            return sketch_list
+
+        def get_fqbn_list(self, args):
+            """
+            Get the list of fqbn for a given sketch.
+            If a fqbn is not provided, then it will get the list
+            from the configuration matrix file.
+            """
+            if args.fqbn is None:
+                ci_config = self.__main_parser_func(args)
+                fqbn_list = ci_config.get_list("fqbn")
+                fqbn_list = fqbn_list["fqbn"]
+            else:
+                fqbn_list = [args.fqbn]
+
+            return fqbn_list
+
+
+        compile_report = CiCompileReport()
+
+        fqbn_list = get_fqbn_list(self, args)
+
+        for fqbn in fqbn_list:
+            print("\n\033[94m--------------------------------------------------------")
+            print(f"--> fqbn: {fqbn}")
+            print("--------------------------------------------------------\033[0m")
+            sketch_list = get_sketch_list(self, args, fqbn)
+            for sketch in sketch_list:
+                command = [
+                    "arduino-cli",
+                    "compile",
+                    "--fqbn",
+                    fqbn,
+                    sketch
+                ]
+
+                print("\033[94m>> \033[0m", end="")
+                print(f"Compiling \"{sketch}\"", end="", flush=True)
+                compile_proc = subprocess.run(command, capture_output=True, text=True, check=False)
+
+                if compile_proc.returncode != 0:
+                    print("\033[91m [FAIL] \033[0m")
+                    print(compile_proc.stderr)
+                    compile_report.add_fail(sketch)
+                else:
+                    print("\033[92m [PASS] \033[0m")
+                    if args.verbose:
+                        print(compile_proc.stdout)
+                    compile_report.add_pass(sketch)
+
+            compile_report.summary()
+            if compile_report.get_fail_len() > 0:
+                sys.exit(1)
+
+    def __create_parser(self):
+        """
+        Creates the argument parser for the build CI matrix script.
+        """
+        def add_shared_args(parser):
+            # Argument for ci matrix yaml file
+            parser.add_argument(
+                "-c",
+                "--ci-matrix-yml",
+                type=str,
+                default=None,
+                help='The path to the ci matrix configuration yml file. Default for libraries is different than for cores.',
+            )
+
+            # Argument for asset (core or library) root path
+            parser.add_argument(
+                "-r",
+                "--root-path",
+                type=str,
+                default=os.getcwd(),
+                help="Path to the arduino asset (library or core) root directory. Default is the current directory",
+            )
+
+            # Argument for verbose output
+            parser.add_argument(
+                "--verbose",
+                action="store_true",
+                default=False,
+                help="Verbose output",
+            )
+
+        self.parser = argparse.ArgumentParser(
+            description="CI utility for Arduino assets",
+        )
+
+        # Argument for version
+        self.parser.add_argument(
+            "-v",
+            "--version",
+            action=self.__ver_action,
+            help=self.ci_tool_name + " version",
+        )
+
+        # Set the main parser function
+        self.parser.set_defaults(func=self.__main_parser_func)
+        add_shared_args(self.parser)
+
+        # Add subparsers 
+        subparsers = self.parser.add_subparsers()
+
+        # Add the config subparser
+        config_parser = subparsers.add_parser(
+            "config",
+            help="CI configuration matrix",
+        )
+        config_parser.set_defaults(func=self.__config_parser_func)
+        add_shared_args(config_parser)
+
+        config_exclusive_group = config_parser.add_mutually_exclusive_group(required=False)
+
+        # Argument for json pretty output
+        config_exclusive_group.add_argument(
+            "--json-pretty",
+            action="store_true",
+            default=False,
+          help="Output the configuration in JSON format",
+        )
+        
+        # Argument for yaml output
+        config_exclusive_group.add_argument(
+            "--yaml",
+            action="store_true",
+            default=False,
+            help="Output the configuration in YAML format",
+        )
+
+        # Argument for query list
+        config_parser.add_argument(
+            "--list",
+            type=str,
+            default=None,
+            help="List all the elements of a given key in the configuration matrix",
+        )
+
+        # Argument for filtering the query list
+        config_parser.add_argument(
+            "--filter",
+            type=str,
+            default=None,
+            help="Filter the list of elements based on a give the value of another key",
+        )
+
+        # Add the config subparser
+        compile_parser = subparsers.add_parser(
+            "compile",
+            help="Compile the ci matrix sketches for a given fqbn",
+        )
+        compile_parser.set_defaults(func=self.__compile_parser_func)
+        add_shared_args(compile_parser)
+
+        # Argument for the compiled fqbn
+        compile_parser.add_argument(
+            "--fqbn",
+            type=str,
+            default=None,
+            help="The fqbn of the board to user for compilation",
+        )
+
+        # Argument for the compiled sketch
+        compile_parser.add_argument(
+            "--sketch",
+            type=str,
+            default=None,
+            help="The sketch to be compiled",
+        )
+
+
+if __name__ == "__main__":
+
+    ci_parser = CiParser()

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,17 @@
+# CLI Tests
+
+This directory contains tests for the CLI utilities in arduino-devops.
+
+These tests serve as a collection of examples and use cases for the CLI, demonstrating how to use the various commands and options available in the package. They are not exhaustive and do not cover every possible scenario, but they check the happy path and main functionality of the CLI.
+
+The test tool used is [shelltestrunner](https://github.com/simonmichael/shelltestrunner) V1.9.0.1. 
+
+It can be easily installed (Linux/Ubuntu only) using the following command:
+```
+$ apt install shelltestrunner
+```
+Go to the `tests` directory and run the tests calling `shelltest` with the test file as an argument. For example:
+```
+$ cd <path_to_arduino-devops_parent_dir>/arduino-devops/tests
+$ shelltest <test_file>
+```

--- a/tests/arduino-ci-config.test
+++ b/tests/arduino-ci-config.test
@@ -1,0 +1,231 @@
+#####################################################################
+# These tests are validating the different options
+# of the "config" subparser command of the arduino-ci.py 
+# utility. 
+# These tests are a not intended for coverage, but the argparser
+# CLI main features.
+
+# These test are based on the provided values of the dummy 
+# "ci-matrix-config.yml" file located in the same directory.
+# Therefore, no autodiscovery of the matrix default values 
+# is evaluated in these tests.
+#####################################################################
+
+# 1. config_no_flags
+# The "config" command returns the configuration 
+# the CI matrix as unformatted JSON.
+
+$ python ../arduino-ci.py config
+{'fqbn': ['fqbn_a', 'fqbn_b', 'fqbn_c', 'fqbn_c_variant', 'fqbn_to_exclude_generally'], 'sketch': ['sketch_a/sketch_a.ino', 'sketch_b/sketch_b.ino', 'sketch_c/sketch_c.ino', 'library_path_a/', 'some_path/test_sketch/test_sketch.ino'], 'include': [{'fqbn': 'additional_board', 'sketch': ['very_specific_example/very_specific_example.ino', 'second_specific_test/second_specific_test.ino']}, {'fqbn': 'fqbn_zzz', 'sketch': 'sketch_a/sketch_a.ino'}, {'fqbn': 'boardy_board', 'sketch': 'some_path_of_a_library/'}, {'sketch': 'a_sketch_to_include_generally.ino'}], 'exclude': [{'fqbn': 'fqbn_c', 'sketch': 'sketch_b/sketch_b.ino'}, {'fqbn': 'fqbn_to_exclude_generally'}], 'asset_type': 'core'}
+
+# 2. config_json_pretty
+# The "--json-pretty" flag returns the configuration 
+# the CI matrix as formatted JSON.
+
+$ python ../arduino-ci.py config --json-pretty
+{
+    "fqbn": [
+        "fqbn_a",
+        "fqbn_b",
+        "fqbn_c",
+        "fqbn_c_variant",
+        "fqbn_to_exclude_generally"
+    ],
+    "sketch": [
+        "sketch_a/sketch_a.ino",
+        "sketch_b/sketch_b.ino",
+        "sketch_c/sketch_c.ino",
+        "library_path_a/",
+        "some_path/test_sketch/test_sketch.ino"
+    ],
+    "include": [
+        {
+            "fqbn": "additional_board",
+            "sketch": [
+                "very_specific_example/very_specific_example.ino",
+                "second_specific_test/second_specific_test.ino"
+            ]
+        },
+        {
+            "fqbn": "fqbn_zzz",
+            "sketch": "sketch_a/sketch_a.ino"
+        },
+        {
+            "fqbn": "boardy_board",
+            "sketch": "some_path_of_a_library/"
+        },
+        {
+            "sketch": "a_sketch_to_include_generally.ino"
+        }
+    ],
+    "exclude": [
+        {
+            "fqbn": "fqbn_c",
+            "sketch": "sketch_b/sketch_b.ino"
+        },
+        {
+            "fqbn": "fqbn_to_exclude_generally"
+        }
+    ],
+    "asset_type": "core"
+}
+
+# 3. config_yaml
+# The "--yaml" flag returns the configuration 
+# the CI matrix in YAML format.
+
+$ python ../arduino-ci.py config --yaml
+asset_type: core
+exclude:
+-   fqbn: fqbn_c
+    sketch: sketch_b/sketch_b.ino
+-   fqbn: fqbn_to_exclude_generally
+fqbn:
+- fqbn_a
+- fqbn_b
+- fqbn_c
+- fqbn_c_variant
+- fqbn_to_exclude_generally
+include:
+-   fqbn: additional_board
+    sketch:
+    - very_specific_example/very_specific_example.ino
+    - second_specific_test/second_specific_test.ino
+-   fqbn: fqbn_zzz
+    sketch: sketch_a/sketch_a.ino
+-   fqbn: boardy_board
+    sketch: some_path_of_a_library/
+-   sketch: a_sketch_to_include_generally.ino
+sketch:
+- sketch_a/sketch_a.ino
+- sketch_b/sketch_b.ino
+- sketch_c/sketch_c.ino
+- library_path_a/
+- some_path/test_sketch/test_sketch.ino
+
+>= #shelltest-delimiter
+
+# 4. config_list_fqnb 
+# The "--list" <key> returns all the values contained
+# in that key in the ci matrix configuration. The allowed
+# keys are "fqbn" o "sketch". 
+# In this case, the fqbn list is requested, and it provides the 
+# default list of "fqbn" plus any additional if included 
+# in the "include" key. 
+# A "fqbn" include in the default "fbqn" is excluded from the
+# "exclude" list as well. 
+# Additionally, it is returned in pretty JSON format.
+
+$ python ../arduino-ci.py config --list fqbn --json-pretty
+{
+    "fqbn": [
+        "additional_board",
+        "boardy_board",
+        "fqbn_a",
+        "fqbn_b",
+        "fqbn_c",
+        "fqbn_c_variant",
+        "fqbn_zzz"
+    ]
+}
+
+# 5. config_list_sketch 
+# The "--list" <key> returns all the values contained
+# in that key in the ci matrix configuration. The allowed
+# keys are "fqbn" o "sketch". 
+# In this case, the sketch list is requested, and it provides the 
+# default list of "sketch" plus any additional if included 
+# in the "include" key.  
+# Additionally, it is returned in yaml format.
+
+$ python ../arduino-ci.py config --list sketch --yaml
+sketch:
+- a_sketch_to_include_generally.ino
+- library_path_a/
+- second_specific_test/second_specific_test.ino
+- sketch_a/sketch_a.ino
+- sketch_b/sketch_b.ino
+- sketch_c/sketch_c.ino
+- some_path/test_sketch/test_sketch.ino
+- some_path_of_a_library/
+- very_specific_example/very_specific_example.ino
+
+>=
+
+# 6. config_list_invalid_key
+# Try to list a key that is not allowed.
+
+$ python ../arduino-ci.py config --list invalid_key
+{'invalid_key': []}
+>2
+ERROR: Key "invalid_key" is not allowed. Allowed keys are: "['fqbn', 'sketch']"
+
+# 7. config_list_filter_invalid_filter_format
+# The filter does not follow the convention "key=value"
+
+$ python ../arduino-ci.py config --list fqbn --filter invalid_filter
+{'fqbn': []}
+>2
+ERROR: Filter "invalid_filter" is not in the format key=value
+
+# 8. config_list_filter_invalid_key
+# The key of the filter is not an allowed or valid key
+
+$ python ../arduino-ci.py config --list fqbn --filter invalid_key=yes
+{'fqbn': []}
+>2
+ERROR: Key "invalid_key" is not allowed. Allowed keys are: "['fqbn', 'sketch']"
+
+# 9. config_list_sketch_filter_sketch_no_match 
+# In this test the "--filter" flag is used to check if a value
+# is present in the CI configuration matrix. 
+# When it is not, it returns an empty list.
+# The "--filter" flag is is used together with "--list".
+# For a non-existing "sketch":
+
+$ python ../arduino-ci.py config --list sketch --filter sketch=non-existing
+{'sketch': []}
+
+
+# 10. config_list_sketch_filter_sketch_match 
+# In this test the "--filter" flag is used to check if a value
+# is present in the CI configuration matrix. 
+# When it is not, it returns an empty list.
+# The "--filter" flag is is used together with "--list".
+# For a the existing "sketch":
+
+$ python ../arduino-ci.py config --list sketch --filter sketch=very_specific_example/very_specific_example.ino
+{'sketch': ['very_specific_example/very_specific_example.ino']}
+
+# 11. config_list_fqbn_filter_fqbn_match
+# In this test the "--filter" flag to return the list of 
+# values of key which match the value of another key in the
+# configuration.
+# When it is not, it returns an empty list.
+# The "--filter" flag is is used together with "--list".
+# Check a for "fqbn" in the main matrix:
+
+$ python ../arduino-ci.py config --list fqbn --filter fqbn=fqbn_c
+{'fqbn': ['fqbn_c']}
+
+# 12. config_list_sketch_filter_fqbn_no_existing_fqbn
+
+$ python ../arduino-ci.py config --list sketch --filter fqbn=non-existing
+{'sketch': []}
+
+# 13. config_list_sketch_filter_fqbn_only_main
+$ python ../arduino-ci.py config --list sketch --filter fqbn=fqbn_b
+{'sketch': ['a_sketch_to_include_generally.ino', 'library_path_a/', 'sketch_a/sketch_a.ino', 'sketch_b/sketch_b.ino', 'sketch_c/sketch_c.ino', 'some_path/test_sketch/test_sketch.ino']}
+
+# 14. config_list_fqbn_filter_sketch_only_main
+$ python ../arduino-ci.py config --list fqbn --filter sketch=library_path_a/
+{'fqbn': ['fqbn_a', 'fqbn_b', 'fqbn_c', 'fqbn_c_variant']}
+
+# 15. config_list_fqbn_filter_sketch_in_include
+$ python ../arduino-ci.py config --list fqbn --filter sketch=sketch_a/sketch_a.ino
+{'fqbn': ['fqbn_a', 'fqbn_b', 'fqbn_c', 'fqbn_c_variant', 'fqbn_zzz']}
+
+# 16. config_list_sketch_filter_fqbn_in_exclude
+$ python ../arduino-ci.py config --list sketch --filter fqbn=fqbn_c
+{'sketch': ['a_sketch_to_include_generally.ino', 'library_path_a/', 'sketch_a/sketch_a.ino', 'sketch_c/sketch_c.ino', 'some_path/test_sketch/test_sketch.ino']}
+

--- a/tests/ci-matrix-config.yml
+++ b/tests/ci-matrix-config.yml
@@ -1,0 +1,33 @@
+# This is a dummy ci matrix configuration file for testing 
+# the arduino-ci.py utility.
+fqbn:
+  - fqbn_a
+  - fqbn_b
+  - fqbn_c
+  - fqbn_c_variant
+  - fqbn_to_exclude_generally
+
+sketch:
+  - sketch_a/sketch_a.ino
+  - sketch_b/sketch_b.ino
+  - sketch_c/sketch_c.ino
+  - library_path_a/
+  - some_path/test_sketch/test_sketch.ino
+
+include: 
+  - fqbn: additional_board
+    sketch:  
+     - very_specific_example/very_specific_example.ino
+     - second_specific_test/second_specific_test.ino
+  - fqbn: fqbn_zzz
+    sketch: sketch_a/sketch_a.ino
+  - fqbn: boardy_board
+    sketch: some_path_of_a_library/
+  - sketch: a_sketch_to_include_generally.ino
+
+exclude:
+  - fqbn: fqbn_c
+    sketch: sketch_b/sketch_b.ino
+  - fqbn: fqbn_to_exclude_generally
+
+asset_type: core

--- a/tests/ino-ci-psoc6-core.test
+++ b/tests/ino-ci-psoc6-core.test
@@ -1,0 +1,22 @@
+# This is test requires the arduino-devops directory
+# to be in the root folder of the arduino-core-psoc6 repository
+# The ci-matrix-config.yml used is version (commit) e38e47821dc1f24a912b0d61b166ca52cecdd9d6
+
+$ python ../arduino-ci.py config --list sketch -r ./../.. --yaml
+sketch:
+- extras/arduino-examples/examples/01.Basics/Blink/Blink.ino
+- extras/arduino-examples/examples/03.Analog/AnalogInOutSerial/AnalogInOutSerial.ino
+- libraries/SPI/examples/master/master.ino
+- libraries/SPI/examples/slave/slave.ino
+- libraries/WiFi/examples/ConnectNoEncryption/ConnectNoEncryption.ino
+- libraries/WiFi/examples/ConnectWithWPA/ConnectWithWPA.ino
+- libraries/WiFi/examples/ScanNetworks/ScanNetworks.ino
+- libraries/WiFi/examples/SimpleWebServerWiFi/SimpleWebServerWiFi.ino
+- libraries/WiFi/examples/WiFiPing/WiFiPing.ino
+- libraries/WiFi/examples/WiFiWebClient/WiFiWebClient.ino
+- libraries/Wire/examples/master_reader/master_reader.ino
+- libraries/Wire/examples/master_writer/master_writer.ino
+- libraries/Wire/examples/slave_receiver/slave_receiver.ino
+- libraries/Wire/examples/slave_sender/slave_sender.ino
+
+>=

--- a/tests/ino-ci-xmc-core.test
+++ b/tests/ino-ci-xmc-core.test
@@ -1,0 +1,128 @@
+
+# This is test requires the arduino-devops directory
+# to be in the root folder of the XMC-for-Arduino repository
+# The ci-matrix-config.yml used is version (commit) a9ddae541a4c7d20d61acc066ca068c15f76401a
+
+
+# 1. List of sketches for XMC1100_Boot_Kit
+
+$ python ../arduino-ci.py config --list sketch --filter fqbn=Infineon:xmc:XMC1100_Boot_Kit -r ./../.. --yaml
+sketch:
+- libraries/DeviceControlXMC/examples/DieTemperatureMeasurement/DieTemperatureMeasurement.ino
+- libraries/DeviceControlXMC/examples/HeapMemoryMeasurement/HeapMemoryMeasurement.ino
+- libraries/DeviceControlXMC/examples/SleepModeXMC1100/SleepModeXMC1100.ino
+- libraries/DeviceControlXMC/examples/StackMemoryMeasurement/StackMemoryMeasurement.ino
+- libraries/I2S
+- libraries/LED
+- libraries/RTC/examples/SimpleRTC
+- libraries/SPI
+- libraries/Wire
+
+>=
+
+# 2. List of sketches for XMC1100_XMC2GO
+
+$ python ../arduino-ci.py config --list sketch --filter fqbn=Infineon:xmc:XMC1100_XMC2GO -r ./../.. --yaml
+sketch:
+- libraries/DeviceControlXMC/examples/DieTemperatureMeasurement/DieTemperatureMeasurement.ino
+- libraries/DeviceControlXMC/examples/HeapMemoryMeasurement/HeapMemoryMeasurement.ino
+- libraries/DeviceControlXMC/examples/SleepModeXMC1100/SleepModeXMC1100.ino
+- libraries/DeviceControlXMC/examples/StackMemoryMeasurement/StackMemoryMeasurement.ino
+- libraries/I2S
+- libraries/LED
+- libraries/RTC/examples/SimpleRTC
+- libraries/SPI
+- libraries/Wire
+
+>=
+
+# 3. List of sketches for XMC1300_Boot_Kit
+
+$ python ../arduino-ci.py config --list sketch --filter fqbn=Infineon:xmc:XMC1300_Boot_Kit -r ./../.. --yaml
+sketch:
+- libraries/DeviceControlXMC/examples/DieTemperatureMeasurement/DieTemperatureMeasurement.ino
+- libraries/DeviceControlXMC/examples/HeapMemoryMeasurement/HeapMemoryMeasurement.ino
+- libraries/DeviceControlXMC/examples/SleepModeXMC1100/SleepModeXMC1100.ino
+- libraries/DeviceControlXMC/examples/StackMemoryMeasurement/StackMemoryMeasurement.ino
+- libraries/LED
+- libraries/RTC/examples/SimpleRTC
+- libraries/SPI
+- libraries/Wire
+
+>=
+
+# 4. List of sketches for XMC1400_Arduino_Kit
+
+$ python ../arduino-ci.py config --list sketch --filter fqbn=Infineon:xmc:XMC1400_Arduino_Kit -r ./../.. --yaml
+sketch:
+- libraries/DeviceControlXMC/examples/DieTemperatureMeasurement/DieTemperatureMeasurement.ino
+- libraries/DeviceControlXMC/examples/HeapMemoryMeasurement/HeapMemoryMeasurement.ino
+- libraries/DeviceControlXMC/examples/SleepModeXMC1100/SleepModeXMC1100.ino
+- libraries/LED
+- libraries/RTC/examples/SimpleRTC
+- libraries/SPI
+- libraries/Wire
+
+>=
+
+# 5. List of sketches for XMC1400_XMC2GO
+
+$ python ../arduino-ci.py config --list sketch --filter fqbn=Infineon:xmc:XMC1400_XMC2GO -r ./../.. --yaml
+sketch:
+- libraries/CAN
+- libraries/DeviceControlXMC/examples/DieTemperatureMeasurement/DieTemperatureMeasurement.ino
+- libraries/DeviceControlXMC/examples/HeapMemoryMeasurement/HeapMemoryMeasurement.ino
+- libraries/DeviceControlXMC/examples/SleepModeXMC1100/SleepModeXMC1100.ino
+- libraries/I2S
+- libraries/LED
+- libraries/RTC/examples/SimpleRTC
+- libraries/SPI
+- libraries/Wire
+
+>=
+
+# 6. List of sketches for XMC4200_Platform2GO
+
+$ python ../arduino-ci.py config --list sketch --filter fqbn=Infineon:xmc:XMC4200_Platform2GO -r ./../.. --yaml
+sketch:
+- libraries/CAN
+- libraries/DeviceControlXMC/examples/StackMemoryMeasurement/StackMemoryMeasurement.ino
+- libraries/LED
+- libraries/RTC/examples/AlarmRTC/AlarmRTC.ino
+- libraries/RTC/examples/SimpleRTC
+- libraries/SPI
+- libraries/Wire
+
+>=
+
+# 7. List of sketches for XMC4400_Platform2GO
+
+$ python ../arduino-ci.py config --list sketch --filter fqbn=Infineon:xmc:XMC4400_Platform2GO -r ./../.. --yaml
+sketch:
+- libraries/CAN
+- libraries/DeviceControlXMC/examples/StackMemoryMeasurement/StackMemoryMeasurement.ino
+- libraries/LED
+- libraries/RTC/examples/SimpleRTC
+- libraries/SPI
+- libraries/Wire
+
+>=
+
+# 8. List of sketches for XMC4700_Relax_Kit
+
+$ python ../arduino-ci.py config --list sketch --filter fqbn=Infineon:xmc:XMC4700_Relax_Kit -r ./../.. --yaml
+sketch:
+- libraries/CAN
+- libraries/DeviceControlXMC/examples/DieTemperatureMeasurement/DieTemperatureMeasurement.ino
+- libraries/DeviceControlXMC/examples/HeapMemoryMeasurement/HeapMemoryMeasurement.ino
+- libraries/DeviceControlXMC/examples/SleepModeXMC4700/SleepModeXMC4700.ino
+- libraries/DeviceControlXMC/examples/StackMemoryMeasurement/StackMemoryMeasurement.ino
+- libraries/DMA
+- libraries/I2S
+- libraries/LED
+- libraries/RTC/examples/AlarmRTC/AlarmRTC.ino
+- libraries/RTC/examples/SimpleRTC
+- libraries/SPI
+- libraries/Wire
+
+>=


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

* The original "compile-examples.yml" is now creating a job group per operating system to help clustering the compile-check list.

* The main compile check functionality is now moved to "compile-examples-os.yml" which essentially does the same as before: compile the matrix of fqbn-examples. The main difference is that now the "os" is passed as input, and that only a job per board (fqbn) is created. In that job all (and only the relevant) examples for a fqbn are compiled.
A generic "compile-setup" step is added that will be used to "git submodule update --init extras/arduino-examples" from the workflow caller --> (https://github.com/jaenrig-ifx/arduino-core-psoc6/blob/compile-example-workflow-update/.github/workflows/compile_examples.yml#L11)

* The "arduino-ci.py" script is taking care of handling the fqbn-sketch matrix generation and its compilation, with multiple features as autodiscovery of fqbn and sketches, and modifiers for including and excluding options from the default fqbn-sketch combination. Lord of clean code forgive me: The script needs to be cleanup a bit with some refactoring and documentation. So the readability is not the best, but i will take care of this in the next iteration (as libraries are yet not included). 
Some basic shell cli test are added as I was checking if all these work for the currently supported cores.

Once this is reviewed and merged, I will cleanup the test branches from both projects and open the respective PR:
https://github.com/jaenrig-ifx/arduino-core-psoc6/actions/runs/14886452897
https://github.com/jaenrig-ifx/XMC-for-Arduino/actions/runs/14886542653

For example, here we see the job output for XMC1400_Boot_kit in XMC-for-Arduino, with the relevant sketched for that board:
![image](https://github.com/user-attachments/assets/051341db-2c1d-463f-9ede-91b0ff6624ad)


