### PR TITLE
New release flow

### DIFF
--- a/.github/workflows/package-core.yml
+++ b/.github/workflows/package-core.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set packager options
         run: |
           if [ "${{ inputs.release }}" = "false" ]; then
-            echo "packager_opts=--no-version-check --no-previous-releases" >> $GITHUB_ENV
+            echo "packager_opts=--no-previous-releases" >> $GITHUB_ENV
           else
             echo "packager_opts=" >> $GITHUB_ENV
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,53 +1,90 @@
 name: Release
 
 on:
-  release:
-    types: published
-  push:
-    tags: 
-      - '[0-9]+.[0-9]+.[0-9]+**'
   workflow_call:
     inputs:
-      release-title:
-        required: true
-        type: string
-        description: 'The title of the release'
       setup-script:
         required: false
         type: string
         default: null
         description: 'Any setup script to run before building the release assets'
+      version:
+        required: false
+        default: ''
+        type: string
+        description: 'Version to be used for the release. It can be a semver version or a bump type (major, minor, patch).'
 
 jobs:
-
-  core-package:
-    if: startsWith(github.ref, 'refs/tags/')
-    uses: Infineon/arduino-devops/.github/workflows/package-core.yml@latest
-    with:
-      setup-script: ${{ inputs.setup-script }}
-      release: true
-    secrets: inherit
-
   release:
-    needs: core-package
     runs-on: ubuntu-latest
-
-    if: startsWith(github.ref, 'refs/tags/')
     steps:
-    - name: Retrieve core package
-      uses: actions/download-artifact@v4
+      - name: Checkout repository 
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-tags: true
+          fetch-depth: 0
 
-    - name: Build release changelog
-      id: build_changelog
-      uses: mikepenz/release-changelog-builder-action@v3
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout arduino-devops
+        uses: actions/checkout@v4
+        with:
+          repository: Infineon/arduino-devops
+          ref: latest
+          path: arduino-devops
 
-    - name: Upload assets
-      uses: softprops/action-gh-release@v1
-      with:
-        name: ${{ inputs.release-title }} ${{  github.ref_name  }}
-        files: |
-          arduino-core-package/*.zip
-          arduino-core-package/*.json
-        body: ${{steps.build_changelog.outputs.changelog}}
+      - name: Install python dependencies
+        run: |
+            python -m pip install --upgrade pip
+            pip install -r arduino-devops/requirements.txt
+
+      - name: Auto tag release
+        if: ${{ inputs.version != '' }}
+        run: |
+          python ./arduino-devops/arduino-release.py new ${{ inputs.version }}
+
+      - name: Release verify
+        run: |
+          python ./arduino-devops/arduino-release.py verify
+
+      - name: Release info
+        id: release_info
+        run: |
+          head_tag=$(python ./arduino-devops/arduino-release.py info head-tag)
+          repo_name=$(python ./arduino-devops/arduino-release.py info repo-name)
+          asset_type=$(python ./arduino-devops/arduino-release.py info asset-type)
+          
+          echo "Repository name: $repo_name"
+          echo "Asset type: $asset_type"
+          echo "Head tag: $head_tag"
+          
+          echo "tag="$head_tag"" >> $GITHUB_OUTPUT
+          echo "repo_name="$repo_name"" >> $GITHUB_OUTPUT
+          echo "asset_type="$asset_type"" >> $GITHUB_OUTPUT
+      
+      - name: Release setup
+        if : ${{ inputs.setup-script }} != null
+        run: |
+          ${{ inputs.setup-script }}
+  
+      - name: Pack arduino core
+        if: ${{ steps.release_info.outputs.asset_type == 'core' }}
+        run: |
+          python ./arduino-devops/arduino-packager.py
+
+      - name: Build release changelog
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v5
+        with:
+          mode: "HYBRID"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ steps.release_info.outputs.repo_name }} ${{ steps.release_info.outputs.tag }}
+          tag_name: ${{ steps.release_info.outputs.tag }}
+          files: |
+            build/*.zip
+            build/*.json
+          body: ${{steps.build_changelog.outputs.changelog}}

--- a/arduino-packager.py
+++ b/arduino-packager.py
@@ -7,6 +7,7 @@ import yaml
 import os
 import re
 import requests
+import semver
 import shutil
 import sys
 import subprocess
@@ -164,32 +165,6 @@ class PackageVersion:
         self.tag = self.__strip_prefix_from_version(git_tag)
         self.commit = git_sha
 
-    def check_consistency(self, platform_txt):
-        """
-        The version consistency check is done by comparing the git
-        versioning and the one in platform.txt.
-
-        These need to be matching in a definitive release.
-
-        Args:
-            - platform_txt: The path to the platform.txt file.
-        """
-
-        # Get the version from the platform.txt
-        with open(platform_txt, "r") as f:
-            lines = f.readlines()
-            for line in lines:
-                if "version=" in line:
-                    platform_version = line.split("=")[1].strip()
-                    break
-
-        # Check if the git tag is the same as the platform version
-        if self.tag != platform_version:
-            logging.error(
-                f"Git tag version {self.tag} does not match the platform version {platform_version}"
-            )
-            sys.exit(1)
-
     """ Private methods """
 
     def __strip_prefix_from_version(self, version):
@@ -338,20 +313,50 @@ class CorePackage:
 
     def __add_version(self, package_version):
         """
-        Creates a file with the version information and
-        add it to the package.
+        Adds the version information to the package in 
+        the platform.txt metadata file and as a separate file 
+        including the tag and commit sha.
 
         Args:
             - package_version: The package version object.
         """
-        version_file = os.path.join(self.pkg_path, ".version")
-        with open(version_file, "w") as f:
-            f.write(f"tag:    {package_version.tag}\n")
-            f.write(f"commit: {package_version.commit }\n")
+        def add_version_to_platform_txt():
+            """
+            Adds the version information to the platform.txt file.
 
-        logging.info(f"Added version information to package in {version_file}")
-        logging.info(f"  - tag:    {package_version.tag}")
-        logging.info(f"  - commit: {package_version.commit}")
+            The platform.txt contains a line with the variable "version="
+            Anything after the "=" will be replaced with the version information.
+
+            """
+            platform_txt = os.path.join(self.pkg_path, "platform.txt")
+
+            with open(platform_txt, "r") as f:
+                lines = f.readlines()
+
+            with open(platform_txt, "w") as f:
+                for line in lines:
+                    if "version=" in line:
+                        f.write(f"version={package_version.tag}\n")
+                    else:
+                        f.write(line)
+            logging.info(f"Added version information to platform.txt in {platform_txt}")
+
+        def add_version_file():
+            """
+            Creates a file with the version information and
+            add it to the package.
+            """
+            version_file = os.path.join(self.pkg_path, ".version")
+            with open(version_file, "w") as f:
+                f.write(f"tag:    {package_version.tag}\n")
+                f.write(f"commit: {package_version.commit }\n")
+
+            logging.info(f"Added version information to package in {version_file}")
+            logging.info(f"  - tag:    {package_version.tag}")
+            logging.info(f"  - commit: {package_version.commit}")
+
+        add_version_to_platform_txt()
+        add_version_file()
 
     def __zip(self):
         """
@@ -467,12 +472,60 @@ class PackageIndex:
     def __get_latest_release_package_index(self):
         """
         Gets the latest release package index from the server.
+        The latest is considered the previous release version.
+        This avoid conflicts when triggering the release directly
+        from the github release section.
 
         Supported servers:
             - Github
 
         Returns an empty index if the package index file does not exist.
         """
+        def get_previous_release_tag():
+            """
+            Get the previous release tag for the repository from the github server.
+            """
+            def get_repo_releases():
+                """
+                Get the list of releases from a the github repository.
+                The API returns a JSON with all information about the releases.
+                """
+                repo_owner = self.server["owner"]
+                repo_name = self.server["repo"]
+                request = f"https://api.github.com/repos/{repo_owner}/{repo_name}/releases"
+                response = requests.get(request)
+                if response.status_code != 200:
+                    logging.error(f"Could not retrieve the latest releases from github. Request error: {response.status_code}")
+                    sys.exit(1)
+                
+                # Iterate over the releases and get the one with the highest tag
+                releases = response.json()
+                return releases
+
+            def search_for_highest_tag(releases):
+                """
+                Search for the highest tag in the releases.
+                This will be the previous release.
+                """
+                tag_list = []
+                for release in releases:
+                    try:
+                        semver.VersionInfo.parse(release["tag_name"])
+                    except ValueError:
+                        logging.warning(f"Tag {release['tag_name']} is not a valid semver tag. Not considered for latest candidate.")
+                        continue
+                    tag_list.append(release["tag_name"])
+
+                tag_list.sort(key=semver.VersionInfo.parse, reverse=True)
+
+                return tag_list[0]
+        
+            releases = get_repo_releases()
+            return search_for_highest_tag(releases)
+        
+
+        previous_tag = get_previous_release_tag()
+
         # Create the url based on the server
         if self.server["type"] == "github":
             url = (
@@ -481,7 +534,9 @@ class PackageIndex:
                 + "/"
                 + str(self.server["repo"])
                 + "/"
-                + "releases/latest/download/"
+                + "releases/download/"
+                + str(previous_tag)
+                + "/"
                 + str(self.pckg_index_name)
                 + ".json"
             )
@@ -597,7 +652,6 @@ def build_release_assets(
     rel_conf_yml,
     core_root_path,
     pkg_build_path,
-    ver_check=True,
     inc_previous_releases=True,
 ):
     """
@@ -609,7 +663,6 @@ def build_release_assets(
         - rel_conf_yml: The path to the release configuration yml file.
         - core_root_path: The path to the arduino core root directory.
         - pkg_build_path: The path to build the package.
-        - ver_check: Assert that versions across core metafiles and git matches.
         - inc_previous_releases: Include previous releases in the package index.
     """
 
@@ -618,10 +671,6 @@ def build_release_assets(
 
     # Get the package version information
     package_version = PackageVersion()
-
-    # Validate the version consistency
-    if ver_check:
-        package_version.check_consistency(os.path.join(core_root_path, "platform.txt"))
 
     # Create the package directory
     core_package = CorePackage(
@@ -659,7 +708,7 @@ class PackageParser:
         """
         # Get the script name without .py extension
         self.package_tool_name = os.path.splitext(os.path.basename(__file__))[0]
-        self.package_tool_version = "0.1.0"
+        self.package_tool_version = "0.2.0"
         self.__create_parser()
 
         args = self.parser.parse_args(namespace=argparse.Namespace(package_parser=self))
@@ -709,7 +758,6 @@ class PackageParser:
             args.config_yml,
             args.root_path,
             args.build_path,
-            args.no_version_check,
             args.no_previous_releases,
         )
 
@@ -766,14 +814,6 @@ class PackageParser:
             type=str,
             default=None,
             help='Path to build the package. Default is the "build/" directory in the arduino core path',
-        )
-
-        # Argument for version check
-        self.parser.add_argument(
-            "--no-version-check",
-            action="store_false",
-            default=True,
-            help="Do not check the version consistency.",
         )
 
         # Argument for previous releases

--- a/arduino-release.py
+++ b/arduino-release.py
@@ -1,0 +1,585 @@
+import argparse
+import json
+import logging
+import os
+import requests
+import sys
+import semver
+import subprocess
+import time
+
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+
+class ReleaseLogger:
+
+    def __init__(self):
+        self.blue_on = "\033[94m"
+        self.green_on = "\033[92m"
+        self.red_on = "\033[91m"
+        self.grey_on = "\033[90m"
+        self.yellow_on = "\033[95m"
+        self.color_off = "\033[0m"
+
+    def ok(self):
+        print(f"{self.green_on} [OK] {self.color_off}")
+    
+    def error(self):
+        print(f"{self.red_on} [ERROR] {self.color_off}")
+    
+    def skip(self):
+        print(f"{self.grey_on} [SKIP] {self.color_off}")
+
+    def info_step(self, msg):
+        print(f"{self.blue_on} -->{self.color_off} {msg}", end=" ")
+        self.last_msg_ncol = len(msg) + len(" -->  ")
+
+    def step_details(self, msg, highlighted="", end="\n"):
+        print(f"     {msg}{self.yellow_on}{highlighted}{self.color_off}", end=end)
+    
+    def del_line(self, time_s=0):
+        time.sleep(time_s)
+        print("\033[F\033[K", end="")
+
+    def cursor_back_up(self):
+        # Move cursor up n lines
+        print(f"\033[F\033[{self.last_msg_ncol}G", end="")
+    
+    def color_msg(self, msg, color, end="\n"):
+        if color == "blue":
+            print(f"{self.blue_on}{msg}{self.color_off}", end=end)
+        elif color == "green":
+            print(f"{self.green_on}{msg}{self.color_off}", end=end)
+        elif color == "red":
+            print(f"{self.red_on}{msg}{self.color_off}", end=end)
+        elif color == "grey":
+            print(f"{self.grey_on}{msg}{self.color_off}", end=end)
+        elif color == "yellow":
+            print(f"{self.yellow_on}{msg}{self.color_off}", end=end)
+        else:
+            print(msg, end=end)
+
+    def wait_progress_animation(self, iterations):
+        # Every iteration will take 4 seconds
+        for j in range(iterations):
+            for i in range(3):
+                print(f"{self.yellow_on}.{self.color_off}", end="", flush=True)
+                time.sleep(1)
+            print("\b\b\b   \b\b\b", end="", flush=True)  
+            time.sleep(1)
+
+class Release:
+
+    def __init__(self, root_path, any_branch=False):
+        """
+        The constructor creates the argument parser and parses the arguments.
+        """
+        self.root_path = root_path
+        self.any_branch = any_branch
+        self.permanent_branches = ["main", "master"]
+        self.skip_workflow = "release"
+        self.log = ReleaseLogger()
+
+    def new(self, version):
+        """
+        Create a new release if all the conditions are met.
+
+        args:
+            version: The new version to be set. It can be either a version number (semver x.y.z) or a version bump (major, minor, patch).
+        """
+
+        self.__assert_permanent_branch()
+        self.__assert_ci_workflows_success()
+        self.__assert_head_not_tagged()
+
+        current_version = self.__get_latest_version()    
+        
+        if version in ["major", "minor", "patch"]: 
+            new_version = self.__new_bump(current_version, version)
+        else:
+            new_version = self.__validate_new_numeric(current_version, version)
+
+        if self.__is_asset_library():
+            self.log.info_step("Updating library.properties file with new version: ")
+            self.__update_lib_properties(new_version)
+            self.__git_commit_change(new_version, user, email)
+        
+        # check here if all works with pre-commit hooks, if we should do the push manually.
+        self.__git_tag(new_version)
+        self.__git_push_tag(new_version)
+
+
+    def verify(self):
+        # all workflows are green for this commit/branch
+        self.__assert_ci_workflows_success()
+        current_tag = self.__get_head_tag()
+        previous_tag = self.__get_previous_tag()
+
+        self.__validate_new_numeric(previous_tag, current_tag)
+        
+        if self.__is_asset_library():
+            pass # TODO: Next iteration. Current focus on core.
+            self.log.info_step("Checking library.properties file with new version: ")
+
+    def info(self, key):
+        if key == "head-tag":
+            print(self.__get_head_tag(log=False))
+        elif key == "repo-name":
+            print(self.__get_repo_owner_name()[1])
+        elif key == "asset-type":
+            # TODO: Implement a proper check for asset type
+            print("library" if self.__is_asset_library() else "core")
+        else:
+            print("Key not recognized. Available keys are: 'head-tag', 'repo-name', 'asset-type'.")
+            sys.exit(1)
+
+    def __validate_new_numeric(self, previous_version, version_bump):
+        # Check if the version is a valid semver version
+        # Check if it is valid increase compared to the previous version
+        try:
+            new_version = semver.VersionInfo.parse(version_bump)
+            previous_version = semver.VersionInfo.parse(previous_version)
+        except ValueError:
+            self.log.error()
+            self.log.step_details("The chosen version is not a valid semver format: ", version_bump)
+            sys.exit(1)
+        
+        def is_valid_increase(new_version, previous_version):
+            #The new version should be greater than the previous version and a valid
+            if new_version.major > previous_version.major:
+                return new_version.major == previous_version.major + 1 and new_version.minor == 0 and new_version.patch == 0
+            elif new_version.minor > previous_version.minor:
+                return new_version.minor == previous_version.minor + 1 and new_version.patch == 0 and new_version.major == previous_version.major
+            elif new_version.patch > previous_version.patch:
+                return new_version.patch == previous_version.patch + 1 and new_version.minor == previous_version.minor and new_version.major == previous_version.major
+            return False
+        
+        def is_valid_from_release_candidate(new_version, previous_version):
+            # The new version should be greater than the previous version and a valid
+            if previous_version.prerelease and \
+                new_version.major == previous_version.major and \
+                new_version.minor == previous_version.minor and \
+                new_version.patch == previous_version.patch and \
+                new_version.prerelease != previous_version.prerelease:
+                return True
+            return False
+
+        self.log.info_step("Validating new version")
+        self.log.color_msg(new_version, "yellow", end="") 
+        self.log.color_msg(" ...", "none", end="") 
+
+        if not is_valid_increase(new_version, previous_version) and \
+           not is_valid_from_release_candidate(new_version, previous_version):
+            self.log.error()
+            self.log.step_details("The new version is not a valid semver increment.")
+            sys.exit(1)
+
+        self.log.ok()
+        return new_version
+
+    def __new_bump(self, previous_version, version_bump):
+        
+        self.log.info_step("New bumped version :")
+
+        new_version = semver.VersionInfo.parse(previous_version)
+        if version_bump == "major":
+            new_version = new_version.bump_major()
+        elif version_bump == "minor":
+            new_version = new_version.bump_minor()
+        elif version_bump == "patch":
+            new_version = new_version.bump_patch()
+
+        self.log.color_msg(new_version, "blue")
+
+        return new_version
+
+    def __assert_permanent_branch(self):
+        """
+        Check if the repo HEAD is in a permanent branch (main or master).
+        """
+        
+        self.log.info_step("Checking if repo HEAD in the default branch...")
+
+        if self.any_branch:
+            self.log.skip()
+            return
+
+        branch = self.__get_head_branch()
+        if branch not in self.permanent_branches:
+            self.log.error()
+            self.log.step_details("Release is allowed only from permanent branches: ", self.permanent_branches)
+            self.log.step_details("HEAD is in branch: ", branch)
+            sys.exit(1)
+        else:
+            self.log.ok()
+
+    
+    def __assert_ci_workflows_success(self):
+        """
+        Check if all the workflows are green for the latest commit in the main branch.
+        """
+
+        def get_workflow_runs(repo_owner, repo_name, branch, commit_hash):
+            request = f"https://api.github.com/repos/{repo_owner}/{repo_name}/actions/runs?branch={branch}&head_sha={commit_hash}" 
+            response = requests.get(request)
+            if response.status_code != 200:
+                self.log.error()
+                self.log.step_details("Error retrieving workflows for commit ", commit_hash)
+                self.log.step_details("Response code: ", response.status_code)
+                sys.exit(1)
+            
+            return response.json().get("workflow_runs", [])
+
+        def assert_workflow_runs_status(workflows):
+            print()
+            for wflow in workflows:
+                self.log.step_details(wflow["name"], end=" ")
+                if wflow["conclusion"] == "failure":
+                    if self.skip_workflow in wflow["name"].lower():
+                        continue
+                    self.log.error()
+                    sys.exit(1)
+                self.log.ok()
+                # Remove back all the lines written here in the console
+                delay_s = 0.5
+                self.log.del_line(delay_s)
+            
+            # Move cursor up to the end of the previous line 
+            self.log.cursor_back_up()
+
+        def assert_workflows_completion(workflows):
+            """
+            Assert that all workflows are completed.
+            """
+            for wflow in workflows:
+                if wflow["status"] == "in_progress" or wflow["status"] == "requested":
+                    # Skip workflows that are related to the release
+                    if self.skip_workflow in wflow["name"].lower():
+                        continue
+                    print()
+                    self.log.step_details(f"Workflow in progress : ", wflow["name"],  end=" ")
+                    self.log.cursor_back_up()
+                    return False
+                
+            return True
+
+
+        branch = self.__get_head_branch()
+        commit_hash = os.popen(f"git -C {self.root_path} rev-parse HEAD").read().strip()
+        repo_owner, repo_name = self.__get_repo_owner_name()
+
+        self.log.info_step("Waiting for all ci workflows completion for HEAD")
+
+        workflows = get_workflow_runs(repo_owner, repo_name, branch, commit_hash)
+        while not assert_workflows_completion(workflows):
+            iter_for_16_s = 4 # Each iteration will take 4 seconds
+            self.log.wait_progress_animation(iter_for_16_s)
+            workflows = get_workflow_runs(repo_owner, repo_name, branch, commit_hash)
+
+        self.log.color_msg("...", None , end="")
+        self.log.ok()
+            
+        self.log.info_step("Checking if all ci workflows are successful for HEAD...")
+
+        workflows = get_workflow_runs(repo_owner, repo_name, branch, commit_hash)
+        assert_workflow_runs_status(workflows)
+
+        self.log.ok()
+
+
+    def __get_head_branch(self):
+        return os.popen(f"git -C {self.root_path} rev-parse --abbrev-ref HEAD").read().strip()
+
+    def __get_repo_owner_name(self):
+        remote = os.popen(f"git -C {self.root_path} config --get remote.origin.url").read().strip()
+        gh_https_url = "https://github.com/"
+        gh_ssh_url = "git@github.com:"
+
+        if gh_https_url in remote:
+            # The owner is the fourth substring of the URL splitted by "/"
+            owner = remote.split("/")[3]
+            # The name is the fifth substring of the URL splitted by "/"
+            if remote.endswith(".git"):
+                name = remote.split("/")[4][:-4]
+            else:
+                name = remote.split("/")[4]
+            return owner, name
+        elif gh_ssh_url in remote:
+            # The owner is just the first part of the URL after the semicolon
+            owner = remote.split(":")[1].split("/")[0]
+            # The owner is the second part of the URL after the semicolon
+            if remote.endswith(".git"):
+                name = remote.split(":")[1].split("/")[1][:-4]
+            else:
+                name = remote.split(":")[1].split("/")[1][:-4]
+            return owner, name
+        else:
+            self.log.error()
+            self.log.step_details("Remote URL is not recognized. Only GitHub remote is supported.")
+            sys.exit(1)
+
+    def __assert_head_not_tagged(self):
+        """
+        Check if the HEAD is tagged.
+        """
+        self.log.info_step("Checking if HEAD is not already tagged...")
+
+        command = ["git", "-C", self.root_path, "describe", "--tags", "--exact-match"]
+        git_proc = subprocess.run(command, capture_output=True, text=True, check=False)
+        
+        if git_proc.returncode == 0:
+            self.log.error()
+            self.log.step_details("This HEAD is already tagged as : ", git_proc.stdout.strip())
+            sys.exit(1)
+        else:
+            self.log.ok()
+
+    def __get_latest_version(self):
+        """
+        Get the last version from the git tags.
+        """
+        self.log.info_step("Previous last version :")
+        command = ["git", "-C", self.root_path, "describe", "--tags", "--abbrev=0"]
+        git_proc = subprocess.run(command, capture_output=True, text=True, check=False)
+
+        if git_proc.returncode != 0:
+            self.log.color_msg("0.0.0", "yellow")
+            self.log.step_details("No tag found. Set the initial version as ", "0.0.0")
+            return "0.0.0"
+
+        last_version = git_proc.stdout.strip()
+        self.log.color_msg(last_version, "blue")
+
+        return last_version
+
+    def __get_head_tag(self, log=True):
+        """
+        Get the tag of the HEAD commit.
+        """
+        if log:
+            self.log.info_step("HEAD tag :")
+
+        command = ["git", "-C", self.root_path, "describe", "--tags", "--exact-match"]
+        git_proc = subprocess.run(command, capture_output=True, text=True, check=False)
+        
+        if git_proc.returncode != 0:
+            if log:
+                self.log.error()
+            self.log.step_details("HEAD is not tagged. ", git_proc.stderr.strip())
+            sys.exit(1)
+        
+        head_tag = git_proc.stdout.strip()
+        if log:
+            self.log.color_msg(head_tag, "blue")
+
+        return head_tag
+
+    def __get_previous_tag(self):
+        """
+        Get the previous tag from the git tags.
+        """
+        self.log.info_step("Previous tag :")
+        command = ["git", "-C", self.root_path, "describe", "--tags", "--abbrev=0", "HEAD^"]
+        git_proc = subprocess.run(command, capture_output=True, text=True, check=False)
+        
+        if git_proc.returncode != 0:
+            self.log.color_msg("0.0.0", "yellow")
+            self.log.step_details("No tag found. Set the initial version as ", "0.0.0")
+            return "0.0.0"
+        
+        previous_tag = git_proc.stdout.strip()
+        self.log.color_msg(previous_tag, "blue")
+
+        return previous_tag
+
+    def __is_asset_library(self):
+        """
+        Checks if the asset is an Arduino library. 
+        If that is the case, it should contain a library.properties file.
+        """
+        if os.path.exists(os.path.join(self.root_path, "library.properties")):
+            return True
+
+        return False
+
+    def __update_lib_properties(self, new_version):
+        pass
+        # TODO: Next iteration. Current focus on core.
+
+    def __git_commit_change(self, new_version, user, email):
+        pass
+        # TODO: Next iteration. Current focus on core.
+    
+    def __git_tag(self, new_version):
+        """
+        Create a new git tag with the new version.
+        """
+        self.log.info_step("Creating new git tag... ")
+        command = ["git", "-C", self.root_path, "tag", str(new_version)]
+        git_proc = subprocess.run(command, capture_output=True, text=True, check=False)
+        
+        if git_proc.returncode != 0:
+            self.log.error()
+            self.log.step_details("Error creating git tag: ", git_proc.stderr.strip())
+            sys.exit(1)
+        
+        self.log.ok()
+
+    def __git_push_tag(self, new_version):
+        """
+        Push the new git tag to the remote repository.
+        """
+        self.log.info_step("Pushing new git tag... ")
+        command = ["git", "push", "origin", str(new_version)]
+        git_proc = subprocess.run(command, capture_output=True, text=True, check=False)
+        
+        if git_proc.returncode != 0:
+            self.log.error()
+            self.log.step_details("Error pushing git tag: ", git_proc.stderr.strip())
+            sys.exit(1)
+        
+        self.log.ok()
+
+class ReleaseParser:
+
+    def __init__(self):
+        """
+        The constructor creates the argument parser and parses the arguments.
+        """
+        self.release_tool_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.release_tool_version = "0.1.0"
+        self.__create_parser()
+
+        args = self.parser.parse_args(namespace=argparse.Namespace(release_parser=self))
+        args.func(args)
+
+    """ Private class methods """
+
+    class __ver_action(argparse.Action):
+        def __init__(self, option_strings, dest, **kwargs):
+            super().__init__(
+                option_strings, dest, nargs=0, default=argparse.SUPPRESS, **kwargs
+            )
+
+        def __call__(self, parser, namespace, values, option_string=None):
+            # Retrieve the package_parser object from the namespace
+            release_parser = getattr(namespace, "release_parser", None)
+            print(
+                release_parser.release_tool_name
+                + " version: "
+                + release_parser.release_tool_version
+            )
+            parser.exit()
+
+    def __main_parser_func(self, args):
+        """
+        Main parser function of arduino release tool.
+        """
+        print("main parser function")
+
+    def __new_version_parser_func(self, args):
+        """
+        Version parser function of arduino release tool.
+        """
+        release = Release(args.root_path, args.any_branch)
+        release.new(args.version)
+    
+    def __verify_parser_func(self, args):
+        """
+        Verify version parser function of arduino release tool.
+        """
+        release = Release(args.root_path)
+        release.verify()
+
+    def __info_parser_func(self, args):
+        """
+        Info version parser function of arduino release tool.
+        """
+        release = Release(args.root_path)
+        release.info(args.key)
+    
+    def __create_parser(self):
+        """
+        Creates the argument parser for the release tool CLI parser.
+        """
+
+        def add_shared_args(parser):
+            # Argument for asset (core or library) root path
+            parser.add_argument(
+                "-r",
+                "--root-path",
+                type=str,
+                default=os.getcwd(),
+                help="Path to the arduino asset (library or core) root directory. Default is the current directory",
+            )
+
+        self.parser = argparse.ArgumentParser(
+            description="Arduino asset release utility",
+        )
+
+        # Argument for version
+        self.parser.add_argument(
+            "-v",
+            "--version",
+            action=self.__ver_action,
+            help=self.release_tool_name + " version",
+        )
+
+        # Set the main parser function
+        self.parser.set_defaults(func=self.__main_parser_func)
+        add_shared_args(self.parser)    
+
+        # Add subparsers 
+        subparsers = self.parser.add_subparsers()
+
+        # Add the "new" subparser
+        new_parser = subparsers.add_parser(
+            "new",
+            help="Create a new release",
+        )
+        new_parser.set_defaults(func=self.__new_version_parser_func)  
+        add_shared_args(new_parser)
+
+        # Argument for the new version
+        new_parser.add_argument(
+            "version",
+            type=str,
+            default=None,
+            help="New version to be set. It can be either a version number (semver x.y.z) or a version bump (major, minor, patch)",
+        )
+
+        # Argument for any branch
+        new_parser.add_argument(
+            "--any-branch",
+            action="store_true",
+            default=False,
+            help="Bypass release requirement: HEAD from permanent branch (main or master)"
+        )
+
+        # Add the "verify" subparser
+        verify_parser = subparsers.add_parser(
+            "verify",
+            help="Verify all requirements are met for a new release",
+        )
+        verify_parser.set_defaults(func=self.__verify_parser_func)
+        add_shared_args(verify_parser)
+
+        # Add the "info" subparser
+        info_parser = subparsers.add_parser(
+            "info",
+            help="Release information",
+        )
+        info_parser.set_defaults(func=self.__info_parser_func)
+        add_shared_args(info_parser)
+
+        # Argument for info value
+        info_parser.add_argument(
+            "key",
+            type=str,
+            default=None,
+            help="Info key to be printed. It can be either 'head-tag', 'repo-name' or 'asset-type'.",
+        )
+
+
+if __name__ == "__main__":
+
+    release_parser = ReleaseParser()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-PyYAML
-requests
+PyYAML >= 6.0.1
+requests >= 2.31.0
+semver >= 3.0.4


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

* Added `arduino-release.py` which supports automatic tagging and release verification. The tag needs to be a valid semver increase on the permanent branches (main, master) and all the commit hash related workflows need to be completed successfully. 
* Updated `release.yml` workflow to enable auto release (from workflow_dispatch), release verify.
* Updated  `release.yml` workflow with newer actions of changelog builder and release creation. Release info resolved with the help of `arduino-release.py`.
* In `arduino-packager.py` we have the following modifications:
- Removed version checking.
- platform.txt version is automatically added during package generation.
- Previous release is not the "latest" Github version, but the previous semver "version". This avoid no history when directly tagging from the release sections.

Example of this workflow run:
https://github.com/jaenrig-ifx/arduino-core-psoc6/actions/runs/15345812209

Next todos:
- One this is merged and marked as latest, it will be updated in xmc-for-arduino and arduino-core-psoc. Test branch already there -> https://github.com/jaenrig-ifx/arduino-core-psoc6/actions/runs/15345812209
- Enable library support in `arduino-release.py ` and `release.yml` 
- Cleanup and docu of `arduino-release.py`
