### PR TITLE
Arduino ci improvements

### DIFF
--- a/.github/workflows/compile-examples-lib.yml
+++ b/.github/workflows/compile-examples-lib.yml
@@ -51,9 +51,10 @@ jobs:
         run: |
           python ./arduino-devops/arduino-cli-install.py 1.2.0
 
-      - name: Install fqbn core
+      - name: Install library dependencies
         run: |
           python ./arduino-devops/arduino-ci.py core-install --fqbn ${{ matrix.fqbn }}
+          python ./arduino-devops/arduino-ci.py lib-deps-install
 
       - name: Compile examples
         run: |

--- a/arduino-ci.py
+++ b/arduino-ci.py
@@ -1272,7 +1272,7 @@ class CiParser:
         """
         # Get the script name without .py extension
         self.ci_tool_name = os.path.splitext(os.path.basename(__file__))[0]
-        self.ci_tool_version = "0.2.0"
+        self.ci_tool_version = "0.3.0"
         self.__create_parser()
 
         args = self.parser.parse_args(namespace=argparse.Namespace(ci_parser=self))
@@ -1299,6 +1299,15 @@ class CiParser:
     def __main_parser_func(self, args):
         """
         Main parser function of arduino CI cli tool
+        """
+        self.parser.print_help()
+
+    def __get_ci_config(self, args):
+        """
+        Get ci configuration instance
+        If no configuration file is provided,
+        it will use the default configuration file
+        in the root path of the asset.
         """
         if args.ci_matrix_yml is None:
             args.ci_matrix_yml = os.path.join(args.root_path, "ci-matrix-config.yml")
@@ -1337,7 +1346,7 @@ class CiParser:
             else:
                 print(queried_config)
 
-        ci_config = self.__main_parser_func(args)
+        ci_config = self.__get_ci_config(args)
         queried_config = get_queried_config(ci_config, args)
         print_config(queried_config, args)
         
@@ -1345,7 +1354,7 @@ class CiParser:
         """
         Compile parser function of arduino CI cli tool
         """
-        ci_config = self.__main_parser_func(args)
+        ci_config = self.__get_ci_config(args)
         ci_compiler = CiCompiler(ci_config)
         ci_compiler.compile(args.fqbn, args.sketch)
 
@@ -1353,7 +1362,7 @@ class CiParser:
         """
         Core install parser function of arduino CI cli tool
         """
-        ci_config = self.__main_parser_func(args)
+        ci_config = self.__get_ci_config(args)
         ci_core_installer = CiCoreInstaller(ci_config)
         ci_core_installer.install(args.fqbn)
 

--- a/arduino-ci.py
+++ b/arduino-ci.py
@@ -484,6 +484,8 @@ class CiMatrixConfig:
                             # to avoid absolute path in the sketch list
                             sketch_with_full_path = os.path.join(root, file)
                             sketch_with_relative_path = os.path.relpath(sketch_with_full_path, self.asset_root_path)
+                            # Exchange backslash with forward slash (in case of Windows)
+                            sketch_with_relative_path = sketch_with_relative_path.replace("\\", "/")
                             sketch_list.append(sketch_with_relative_path)
         
             return sketch_list
@@ -1054,7 +1056,7 @@ class LibDepsInstaller():
 
         Args:
             - libs (list): A list of libraries to be installed.
-              The library can as well include the version constrains in the format
+              The library can as well include the version constraints in the format
               "library (version)"
         """
         def format_lib_arg(lib):
@@ -1065,12 +1067,12 @@ class LibDepsInstaller():
             or just:
             "library" if no version is specified.
 
-            Check the version constrains formats allowed in library.properties file:
+            Check the version constraints formats allowed in library.properties file:
             # https://docs.arduino.cc/arduino-cli/library-specification/#version-constraints
 
-            This tool right now only supports constrains which explicitly provide a version.
+            This tool right now only supports constraints which explicitly provide a version.
             Meaning those containing an (at least) equal: >=, <=, =.
-            Constrains requiring the discovery of greater, lower or range versions are not (currently) supported.
+            Constraints requiring the discovery of greater, lower or range versions are not (currently) supported.
             """
             # If the lib has a version in parenthesis,
             # the output format will become library@version
@@ -1085,7 +1087,7 @@ class LibDepsInstaller():
                 # Check if this is valid semver version x.y.z. This discard any other not supported constrain.
                 if not re.match(r"^\d+\.\d+\.\d+$", lib_version):
                     logging.error(f"Invalid version format for library \"{lib_name}\" : {lib_version}. \n \
-                    \rOnly versions constrains \"=, <=, >=\" are implemented.\n \
+                    \rOnly versions constraints \"=, <=, >=\" are implemented.\n \
                     \rNo discovery of greater, lower or range versions in this tool.")
                     sys.exit(1)
 
@@ -1108,6 +1110,7 @@ class LibDepsInstaller():
             if lib_install_proc.returncode != 0:
                 logging.error(f"Error installing library \"{lib_arg}\"")
                 print(lib_install_proc.stderr)
+                sys.exit(1)
 
             print(f"Library \"{lib_arg}\" installed successfully.")
 

--- a/arduino-ci.py
+++ b/arduino-ci.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import sys
 import subprocess
 import yaml
@@ -987,6 +988,129 @@ class CiCoreInstaller():
         return False
         
 
+class LibDepsInstaller():
+    """
+    This class is used to install the library dependencies for the sketches.
+    The library dependencies are installed using the "arduino-cli lib install" command.
+    """
+
+    def __init__(self, asset_root_path):
+        """
+        Creates the LibDepsInstaller object.
+
+        Args:
+            - asset_root_path (str): The root path of the asset.
+            This is used to find the library dependencies for the sketches.
+        """
+        self.asset_root_path = asset_root_path
+
+    def install(self):
+        """
+        Installs the library dependencies for a library asset.
+        It inspect the directory for the "library.properties" file,
+        and install them using the "arduino-cli lib install" command.
+        """
+
+        print("Installing library dependencies...")
+        lib_deps = self.__get_lib_deps()
+        if lib_deps:
+            print(f"Found \"{lib_deps}\" library dependencies to install.")
+        else:
+            print("No library dependencies found.")
+            return
+
+        self.__install_lib(lib_deps)
+
+        print("Library dependencies installed successfully.")
+
+    """ Private methods """
+
+    def __get_lib_deps(self):
+        """
+        Gets the library dependencies from the library.properties file.
+
+        The file contains a "depends" key with a comma separated list of libraries.
+        If the key is empty, it will return an empty list.
+        """
+        lib_properties_file = os.path.join(self.asset_root_path, "library.properties")
+        with open(lib_properties_file, "r") as f:
+            lib_properties_content = f.read()
+
+        # Parse the content of the library.properties file and get the "depends" key
+        for line in lib_properties_content.splitlines():
+            if line.startswith("depends="):
+                # The value of the "depends" key is a comma separated list of libraries
+                # Remove the "depends=" prefix from the line
+                line = line.replace("depends=", "")
+                libs = line.strip().split(",")
+                return [lib.strip() for lib in libs if lib.strip() != ""]
+
+    @staticmethod
+    def __install_lib(libs):
+        """
+        Installs each of the library of the list passed by argument.
+
+        The library is installed using the "arduino-cli lib install" command.
+
+        Args:
+            - libs (list): A list of libraries to be installed.
+              The library can as well include the version constrains in the format
+              "library (version)"
+        """
+        def format_lib_arg(lib):
+            """
+            Formats the library to be used as an argument for the "arduino-cli lib install" command
+            in the format:
+            "library@version" if the version is specified,
+            or just:
+            "library" if no version is specified.
+
+            Check the version constrains formats allowed in library.properties file:
+            # https://docs.arduino.cc/arduino-cli/library-specification/#version-constraints
+
+            This tool right now only supports constrains which explicitly provide a version.
+            Meaning those containing an (at least) equal: >=, <=, =.
+            Constrains requiring the discovery of greater, lower or range versions are not (currently) supported.
+            """
+            # If the lib has a version in parenthesis,
+            # the output format will become library@version
+            if "(" in lib and ")" in lib:
+                lib_name = lib.split("(")[0].strip()
+
+                lib_version = lib.split("(")[1].split(")")[0].strip()
+                # Only equal versions will be considered.  No discovery of > or < version will be here implemented.
+                if "<=" in lib_version or ">=" in lib_version or "=" in lib_version:
+                    lib_version = lib_version.replace("<=", "").replace(">=", "").replace("=", "").strip()
+
+                # Check if this is valid semver version x.y.z. This discard any other not supported constrain.
+                if not re.match(r"^\d+\.\d+\.\d+$", lib_version):
+                    logging.error(f"Invalid version format for library \"{lib_name}\" : {lib_version}. \n \
+                    \rOnly versions constrains \"=, <=, >=\" are implemented.\n \
+                    \rNo discovery of greater, lower or range versions in this tool.")
+                    sys.exit(1)
+
+                return f"{lib_name}@{lib_version}"
+            else:
+                return f"{lib}"
+
+
+        for lib in libs:
+            lib_arg = format_lib_arg(lib)
+            command = [
+                "arduino-cli",
+                "lib",
+                "install",
+                lib_arg,
+            ]
+
+            lib_install_proc = subprocess.run(command, capture_output=True, text=True, check=False)
+
+            if lib_install_proc.returncode != 0:
+                logging.error(f"Error installing library \"{lib_arg}\"")
+                print(lib_install_proc.stderr)
+
+            print(f"Library \"{lib_arg}\" installed successfully.")
+
 class CiCompileReport:
     """
     Class that generates the compile report for the compile sketches.
@@ -1370,6 +1494,13 @@ class CiParser:
         ci_core_installer = CiCoreInstaller(ci_config)
         ci_core_installer.install(args.fqbn)
 
+    def __lib_deps_install_parser_func(self, args):
+        """
+        Library deps install parser function of arduino CI cli tool
+        """
+        lib_deps_installer = LibDepsInstaller(args.root_path)
+        lib_deps_installer.install()
+
     def __create_parser(self):
         """
         Creates the argument parser for the build CI matrix script.
@@ -1501,6 +1632,14 @@ class CiParser:
             default=None,
             help="The fqbn of the board to be installed",
         )
+
+        # Add the lib-deps-install subparser
+        lib_deps_install_parser = subparsers.add_parser(
+            "lib-deps-install",
+            help="Install the \"depends\" libraries in the  \"library.properties\" file of the library asset",
+        )
+        lib_deps_install_parser.set_defaults(func=self.__lib_deps_install_parser_func)
+        add_shared_args(lib_deps_install_parser)
 
 
 if __name__ == "__main__":

--- a/arduino-ci.py
+++ b/arduino-ci.py
@@ -743,6 +743,10 @@ class CiMatrixConfig:
         """
         queried_list = { query_key: [] }
 
+        exclude_filter_values = self.__get_values_from_modifier_node_key("exclude", filter_key, single_key_check=True)
+        if filter_value in exclude_filter_values:
+            return queried_list
+
         root_node_key_values = self.__get_values_from_root_node_key(filter_key)
         include_filter_values = self.__get_values_from_modifier_node_key("include", filter_key, single_key_check=True)
         if filter_value in root_node_key_values or filter_value in include_filter_values:   

--- a/arduino-packager.py
+++ b/arduino-packager.py
@@ -518,6 +518,10 @@ class PackageIndex:
 
                 tag_list.sort(key=semver.VersionInfo.parse, reverse=True)
 
+                if not tag_list:
+                    logging.warning("No release found in the repository. Using previous tag as '0.0.0'")
+                    return "0.0.0"
+
                 return tag_list[0]
         
             releases = get_repo_releases()


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

To be reviewed after #14 :

* Added support for Arduino library release in `arduino-release.py` ->  -> https://github.com/jaenrig-ifx/arduino-pas-cotwo-sensor/actions/runs/15440505030/job/43456951274
* Commented and cleanup `arduino-release.py`
* Fixed `arduino-ci.py config --list sketch --filter fqbn=xxx` not filtering single key modifiers in exclude list.
* Fixed `arduino-ci.py` return help if not subparser argument is provided.
* Added `lib-deps-install` command to `arduino-ci.py` to enable compile-examples check for library which specify dependencies. BUT, only limited to latest of versions constrains which explicitly specify a version (>=, <=, =). More about it in https://docs.arduino.cc/arduino-cli/library-specification/#version-constraints > https://github.com/Infineon/TLI4971-Current-Sensor/pull/4
* Added `arduino-ci.py` Win support via sketch paths backslashes replacing for forward slashes.
* Enabled first time release in `arduino-package.py` script when no release history.
* Minor fixes in typo and formatting. 