### PR TITLE
config/ci-config-matrix-ifx-lib.yml: Fixed xmc core name.

### DIFF
--- a/config/ci-config-matrix-ifx-lib.yml
+++ b/config/ci-config-matrix-ifx-lib.yml
@@ -14,7 +14,7 @@ fqbn:
   - infineon:psoc6:cy8ckit_062s2_ai
 
 additional_urls:
-  - core: Infineon:xmc
+  - core: infineon:xmc
     url:  https://github.com/Infineon/XMC-for-Arduino/releases/latest/download/package_xmc_index.json
   - core: infineon:psoc6
     url:  https://github.com/Infineon/arduino-core-psoc6/releases/latest/download/package_psoc6_index.json


### PR DESCRIPTION
* Fixed core name typo.