### PR TITLE
Fixing warning issue with inputs.setup-script check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           echo "asset_type="$asset_type"" >> $GITHUB_OUTPUT
       
       - name: Release setup
-        if : ${{ inputs.setup-script }} != null
+        if: ${{ inputs.setup-script != '' }}
         run: |
           ${{ inputs.setup-script }}
   


### PR DESCRIPTION
A warning always appeared, seemingly from this bug:

Warning message:
```
In .github/workflows/release.yml (Line: 21, Col: 11): Error from called workflow Infineon/arduino-devops/.github/workflows/release.yml@latest (Line: 78, Col: 14): Conditional expression contains literal text outside replacement tokens. This will cause the expression to always evaluate to truthy. Did you mean to put the entire expression inside ${{ }}?
```

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Provide the information we need to review your PR. What problem does the pull request solve? "Bug fix" is not a good description.

Related Issue
If you opened an issue before creating the PR, point to it here.

Context
What do we need to know about your development environment, tools, target, and so on. Screenshots are always helpful if there is a UI element to this PR.